### PR TITLE
Make Icon configuration optional with text fallback

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -1,10 +1,19 @@
 <?php
 
+use Templating\View\Icon\BootstrapIcon;
+
 return [
 	'QueueScheduler' => [
 		// Additional plugins that are not loaded, but should be included, use `-` prefix to exclude
 		'plugins' => [],
 		'allowRaw' => false, // By default, this is only enabled in debug mode for security reasons.
 		'crontabMinimum' => '1 minute', // By default, this should be run as `* * * * *`
+	],
+	// Icon configuration for the backend UI (optional, but recommended for better UX)
+	// Without this, the UI will fall back to text-based icons.
+	'Icon' => [
+		'sets' => [
+			'bs' => BootstrapIcon::class,
+		],
 	],
 ];

--- a/docs/README.md
+++ b/docs/README.md
@@ -157,6 +157,26 @@ You can configure the plugin further through
 in your app.php config.
 For details see `config/app.example.php` file.
 
+### Icons
+The backend UI uses icons for better UX. To enable them, configure an icon set in your `config/app.php`:
+```php
+use Templating\View\Icon\BootstrapIcon;
+
+'Icon' => [
+    'sets' => [
+        'bs' => BootstrapIcon::class,
+    ],
+],
+```
+
+Available icon sets from the Tools plugin:
+- `BootstrapIcon` - Bootstrap Icons
+- `FontAwesome4Icon`, `FontAwesome5Icon`, `FontAwesome6Icon` - Font Awesome
+- `FeatherIcon` - Feather Icons
+- `MaterialIcon` - Material Icons
+
+Without icon configuration, the UI will fall back to text-based labels.
+
 ### Plugins
 If you want to further include/exclude plugins, you can use the `plugins` key. Use `-` prefix to exclude.
 ```php

--- a/src/Controller/Admin/LoadHelperTrait.php
+++ b/src/Controller/Admin/LoadHelperTrait.php
@@ -2,6 +2,7 @@
 
 namespace QueueScheduler\Controller\Admin;
 
+use Cake\Core\Configure;
 use Templating\View\Helper\IconHelper;
 use Templating\View\Helper\IconSnippetHelper;
 use Templating\View\Helper\TemplatingHelper;
@@ -19,8 +20,10 @@ trait LoadHelperTrait {
 			'Tools.Format',
 			'Tools.Text',
 			'Tools.Time',
-			class_exists(IconHelper::class) ? 'Templating.Icon' : 'Tools.Icon',
 		];
+		if (Configure::read('Icon.sets')) {
+			$helpers[] = class_exists(IconHelper::class) ? 'Templating.Icon' : 'Tools.Icon';
+		}
 		if (class_exists(IconSnippetHelper::class)) {
 			$helpers[] = 'Templating.IconSnippet';
 		}

--- a/templates/Admin/QueueScheduler/index.php
+++ b/templates/Admin/QueueScheduler/index.php
@@ -47,7 +47,7 @@
 					<?php if ($queuedJob) { ?>
 					<div class="alert alert-warning">
 						<b><?php echo h($queuedJob->status) ?: 'Queued'?></b>
-						<?php echo $this->Html->link($this->Icon->render('view'), ['plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'view', $queuedJob->id], ['escapeTitle' => false]); ?>
+						<?php echo $this->Html->link($this->element('QueueScheduler.icon', ['name' => 'view']), ['plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'view', $queuedJob->id], ['escapeTitle' => false]); ?>
 
 						<?php if (!$queuedJob->completed && $queuedJob->fetched) { ?>
 							<?php if (!$queuedJob->failure_message) { ?>
@@ -77,9 +77,9 @@
 				</td>
 				<td class="actions">
 					<?php if (!$queuedJob) { ?>
-						<?php echo $this->Form->postLink($this->Icon->render('play-circle', [], ['title' => 'Run manually now']), ['controller' => 'SchedulerRows', 'action' => 'run', $schedulerRow->id], ['escapeTitle' => false, 'class' => 'btn btn-small btn-success', 'confirm' => 'Sure to run it now?']); ?>
+						<?php echo $this->Form->postLink($this->element('QueueScheduler.icon', ['name' => 'play-circle', 'attributes' => ['title' => 'Run manually now']]), ['controller' => 'SchedulerRows', 'action' => 'run', $schedulerRow->id], ['escapeTitle' => false, 'class' => 'btn btn-small btn-success', 'confirm' => 'Sure to run it now?']); ?>
 					<?php } ?>
-					<?php echo $this->Form->postLink($this->Icon->render('no', [], ['title' => 'Disable']), ['controller' => 'SchedulerRows', 'action' => 'edit', $schedulerRow->id], ['data' => ['enabled' => 0], 'escapeTitle' => false, 'class' => 'btn btn-small btn-danger', 'confirm' => 'Sure to disable?']); ?>
+					<?php echo $this->Form->postLink($this->element('QueueScheduler.icon', ['name' => 'no', 'attributes' => ['title' => 'Disable']]), ['controller' => 'SchedulerRows', 'action' => 'edit', $schedulerRow->id], ['data' => ['enabled' => 0], 'escapeTitle' => false, 'class' => 'btn btn-small btn-danger', 'confirm' => 'Sure to disable?']); ?>
 				</td>
 			</tr>
 		<?php } ?>
@@ -88,7 +88,7 @@
 
 
 	<p>
-	<?= $this->Html->link(__('Details'), ['controller' => 'SchedulerRows', 'action' => 'index'], ['class' => 'btn btn-secondary']) ?> <?php echo $this->Form->postLink($this->Icon->render('no', [], ['title' => 'Disable']) . ' ' . __('Disable all'), ['controller' => 'SchedulerRows', 'action' => 'disableAll'], ['escapeTitle' => false, 'class' => 'btn btn-small btn-danger', 'block' => true,  'confirm' => 'Sure to disable all?']); ?>
+	<?= $this->Html->link(__('Details'), ['controller' => 'SchedulerRows', 'action' => 'index'], ['class' => 'btn btn-secondary']) ?> <?php echo $this->Form->postLink($this->element('QueueScheduler.icon', ['name' => 'no', 'attributes' => ['title' => 'Disable']]) . ' ' . __('Disable all'), ['controller' => 'SchedulerRows', 'action' => 'disableAll'], ['escapeTitle' => false, 'class' => 'btn btn-small btn-danger', 'block' => true,  'confirm' => 'Sure to disable all?']); ?>
 	</p>
 
 </div>

--- a/templates/Admin/SchedulerRows/index.php
+++ b/templates/Admin/SchedulerRows/index.php
@@ -66,9 +66,9 @@
 					<td>
 						<?= $this->element('QueueScheduler.yes_no', ['value' => $row->enabled]) ?>
 						<?php if ($row->enabled && $row->type === $row::TYPE_SHELL_COMMAND && !\Cake\Core\Configure::read('QueueScheduler.allowRaw')) { ?>
-							<span><?php echo $this->Icon->render('stop-circle', [], ['title' => 'Raw commands are currently configured to be not runnable on non-debug system for security reasons.']); ?></span>
+							<span><?php echo $this->element('QueueScheduler.icon', ['name' => 'stop-circle', 'attributes' => ['title' => 'Raw commands are currently configured to be not runnable on non-debug system for security reasons.']]); ?></span>
 						<?php } elseif (!$row->enabled && !($row->type === $row::TYPE_SHELL_COMMAND && !\Cake\Core\Configure::read('QueueScheduler.allowRaw'))) { ?>
-							<?php echo $this->Form->postLink($this->Icon->render('yes', [], ['title' => 'Enable']) . ' ' . __('Enable'), ['controller' => 'SchedulerRows', 'action' => 'edit', $row->id], ['data' => ['enabled' => 1], 'escapeTitle' => false, 'class' => 'btn btn-small btn-success', 'confirm' => 'Sure to enable?']); ?>
+							<?php echo $this->Form->postLink($this->element('QueueScheduler.icon', ['name' => 'yes', 'attributes' => ['title' => 'Enable']]) . ' ' . __('Enable'), ['controller' => 'SchedulerRows', 'action' => 'edit', $row->id], ['data' => ['enabled' => 1], 'escapeTitle' => false, 'class' => 'btn btn-small btn-success', 'confirm' => 'Sure to enable?']); ?>
 						<?php } ?>
 
 						<?php if ($row->last_run) { ?>
@@ -88,10 +88,10 @@
 					<td><?= $this->Time->nice($row->created) ?></td>
 					<td><?= $this->Time->nice($row->modified) ?></td>
 					<td class="actions">
-						<?php echo $this->Html->link($this->Icon->render('view'), ['action' => 'view', $row->id], ['escapeTitle' => false]); ?>
-						<?php echo $this->Html->link($this->Icon->render('edit'), ['action' => 'edit', $row->id], ['escapeTitle' => false]); ?>
-						<?php echo $this->Form->postLink($this->Icon->render('play-circle', [], ['title' => 'Run manually now']), ['action' => 'run', $row->id], ['escapeTitle' => false, 'class' => '', 'confirm' => 'Sure to run it now?']); ?>
-					<?php echo $this->Form->postLink($this->Icon->render('delete'), ['action' => 'delete', $row->id], ['escapeTitle' => false, 'confirm' => __('Are you sure you want to delete # {0}?', $row->id)]); ?>
+						<?php echo $this->Html->link($this->element('QueueScheduler.icon', ['name' => 'view']), ['action' => 'view', $row->id], ['escapeTitle' => false]); ?>
+						<?php echo $this->Html->link($this->element('QueueScheduler.icon', ['name' => 'edit']), ['action' => 'edit', $row->id], ['escapeTitle' => false]); ?>
+						<?php echo $this->Form->postLink($this->element('QueueScheduler.icon', ['name' => 'play-circle', 'attributes' => ['title' => 'Run manually now']]), ['action' => 'run', $row->id], ['escapeTitle' => false, 'class' => '', 'confirm' => 'Sure to run it now?']); ?>
+					<?php echo $this->Form->postLink($this->element('QueueScheduler.icon', ['name' => 'delete']), ['action' => 'delete', $row->id], ['escapeTitle' => false, 'confirm' => __('Are you sure you want to delete # {0}?', $row->id)]); ?>
 					</td>
 				</tr>
 				<?php endforeach; ?>

--- a/templates/Admin/SchedulerRows/view.php
+++ b/templates/Admin/SchedulerRows/view.php
@@ -57,7 +57,7 @@
 						<?= $this->element('QueueScheduler.yes_no', ['value' => $row->enabled]) ?> <?= $row->enabled ? __('Yes') : __('No'); ?>
 
 						<?php if (!$row->enabled) { ?>
-							<?php echo $this->Form->postLink($this->Icon->render('yes', [], ['title' => 'Enable']) . ' ' . __('Enable'), ['controller' => 'SchedulerRows', 'action' => 'edit', $row->id], ['data' => ['enabled' => 1], 'escapeTitle' => false, 'class' => 'btn btn-small btn-success', 'confirm' => 'Sure to enable?']); ?>
+							<?php echo $this->Form->postLink($this->element('QueueScheduler.icon', ['name' => 'yes', 'attributes' => ['title' => 'Enable']]) . ' ' . __('Enable'), ['controller' => 'SchedulerRows', 'action' => 'edit', $row->id], ['data' => ['enabled' => 1], 'escapeTitle' => false, 'class' => 'btn btn-small btn-success', 'confirm' => 'Sure to enable?']); ?>
 						<?php } ?>
 					</td>
 				</tr>

--- a/templates/element/icon.php
+++ b/templates/element/icon.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Icon element with text fallback when Icon helper is not available.
+ *
+ * @var \App\View\AppView $this
+ * @var string $name Icon name
+ * @var array<string, mixed> $options Icon options
+ * @var array<string, mixed> $attributes Icon attributes
+ */
+
+$options ??= [];
+$attributes ??= [];
+
+$fallbackMap = [
+	'view' => 'View',
+	'edit' => 'Edit',
+	'delete' => 'Del',
+	'play-circle' => 'Run',
+	'stop-circle' => 'Stop',
+	'yes' => 'Yes',
+	'no' => 'No',
+];
+
+if ($this->helpers()->has('Icon')) {
+	echo $this->Icon->render($name, $options, $attributes);
+} else {
+	$title = $attributes['title'] ?? $fallbackMap[$name] ?? ucfirst($name);
+	echo '<span title="' . h($title) . '">[' . h($fallbackMap[$name] ?? ucfirst($name)) . ']</span>';
+}


### PR DESCRIPTION
## Summary

- Make Icon configuration optional - the backend UI now works without `Icon.sets` configured
- Add text fallback `[View]`, `[Edit]`, `[Run]`, etc. when icons are not available
- Document icon configuration in `docs/README.md`
- Add icon config example to `config/app.example.php`

## Test plan

- [ ] Verify UI works without Icon configuration (shows text fallbacks)
- [ ] Verify UI works with Icon configuration (shows icons as before)

Fixes #11