### PR TITLE
Fix PHP version badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/dereuromark/cakephp-queue-scheduler/actions/workflows/ci.yml/badge.svg)](https://github.com/dereuromark/cakephp-queue-scheduler/actions/workflows/ci.yml)
 [![Coverage Status](https://img.shields.io/codecov/c/github/dereuromark/cakephp-queue-scheduler/master.svg)](https://codecov.io/github/dereuromark/cakephp-queue-scheduler/branch/master)
 [![Latest Stable Version](https://poser.pugx.org/dereuromark/cakephp-queue-scheduler/v/stable.svg)](https://packagist.org/packages/dereuromark/cakephp-queue-scheduler)
-[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%207.4-8892BF.svg)](https://php.net/)
+[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%208.1-8892BF.svg)](https://php.net/)
 [![PHPStan](https://img.shields.io/badge/PHPStan-level%208-brightgreen.svg?style=flat)](https://phpstan.org/)
 [![License](https://poser.pugx.org/dereuromark/cakephp-queue-scheduler/license.svg)](LICENSE)
 [![Total Downloads](https://poser.pugx.org/dereuromark/cakephp-queue-scheduler/d/total)](https://packagist.org/packages/dereuromark/cakephp-queue-scheduler)


### PR DESCRIPTION
## Summary
- Update PHP version badge from 7.4+ to 8.1+ to match composer.json requirements