### PR TITLE
Add direct job linking from scheduler to queue jobs

### DIFF
--- a/config/Migrations/20260129000000_QueueSchedulerJobLink.php
+++ b/config/Migrations/20260129000000_QueueSchedulerJobLink.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\BaseMigration;
+
+class QueueSchedulerJobLink extends BaseMigration {
+
+	/**
+	 * Change Method.
+	 *
+	 * @return void
+	 */
+	public function change(): void {
+		$this->table('queue_scheduler_rows')
+			->addColumn('last_queued_job_id', 'integer', [
+				'default' => null,
+				'null' => true,
+				'signed' => false,
+			])
+			->addIndex(['last_queued_job_id'])
+			->update();
+	}
+
+}

--- a/config/Migrations/20260129000000_QueueSchedulerJobLink.php
+++ b/config/Migrations/20260129000000_QueueSchedulerJobLink.php
@@ -1,5 +1,4 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 use Migrations\BaseMigration;
 

--- a/src/Model/Entity/SchedulerRow.php
+++ b/src/Model/Entity/SchedulerRow.php
@@ -25,6 +25,7 @@ use Tools\Model\Entity\Entity;
  * @property \Cake\I18n\DateTime|null $created
  * @property \Cake\I18n\DateTime|null $modified
  * @property bool $enabled
+ * @property int|null $last_queued_job_id
  * @property-read string|null $job_task
  * @property-read array $job_data
  * @property-read array $job_config

--- a/src/Model/Table/SchedulerRowsTable.php
+++ b/src/Model/Table/SchedulerRowsTable.php
@@ -42,7 +42,7 @@ class SchedulerRowsTable extends Table {
 	/**
 	 * @var array<string>
 	 */
-	public $scaffoldSkipFields = ['last_run'];
+	public $scaffoldSkipFields = ['last_run', 'last_queued_job_id'];
 
 	/**
 	 * Initialize method
@@ -308,8 +308,9 @@ class SchedulerRowsTable extends Table {
 			return false;
 		}
 
-		$queuedJobsTable->createJob($row->job_task, $row->job_data, $config);
+		$queuedJob = $queuedJobsTable->createJob($row->job_task, $row->job_data, $config);
 		$row->last_run = new DateTime();
+		$row->last_queued_job_id = $queuedJob->id;
 		$this->saveOrFail($row);
 
 		return true;

--- a/templates/Admin/QueueScheduler/index.php
+++ b/templates/Admin/QueueScheduler/index.php
@@ -66,7 +66,13 @@
 				</td>
 				<td>
 					<?php if ($schedulerRow->last_run) { ?>
-						<div><small><?= __('Last Run') ?>: <?php echo $this->Time->nice($schedulerRow->last_run); ?></small></div>
+						<div><small><?= __('Last Run') ?>:
+							<?php if ($schedulerRow->last_queued_job_id) { ?>
+								<?= $this->Html->link($this->Time->nice($schedulerRow->last_run), ['plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'view', $schedulerRow->last_queued_job_id], ['escapeTitle' => false]) ?>
+							<?php } else { ?>
+								<?= $this->Time->nice($schedulerRow->last_run) ?>
+							<?php } ?>
+						</small></div>
 					<?php } ?>
 					<?php
 						$nextRun = $schedulerRow->next_run ?: $schedulerRow->calculateNextRun();

--- a/templates/Admin/SchedulerRows/index.php
+++ b/templates/Admin/SchedulerRows/index.php
@@ -72,7 +72,13 @@
 						<?php } ?>
 
 						<?php if ($row->last_run) { ?>
-						<div><small><?= __('Last Run') ?>: <?php echo $this->Time->nice($row->last_run); ?></small></div>
+						<div><small><?= __('Last Run') ?>:
+							<?php if ($row->last_queued_job_id) { ?>
+								<?= $this->Html->link($this->Time->nice($row->last_run), ['plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'view', $row->last_queued_job_id], ['escapeTitle' => false]) ?>
+							<?php } else { ?>
+								<?= $this->Time->nice($row->last_run) ?>
+							<?php } ?>
+						</small></div>
 						<?php } ?>
 						<?php
 							$nextRun = $row->next_run ?: $row->calculateNextRun();

--- a/templates/Admin/SchedulerRows/view.php
+++ b/templates/Admin/SchedulerRows/view.php
@@ -66,7 +66,13 @@
 				</tr>
 				<tr>
 					<th><?= __('Last Run') ?></th>
-					<td><?= $this->Time->nice($row->last_run) ?></td>
+					<td>
+						<?php if ($row->last_run && $row->last_queued_job_id) { ?>
+							<?= $this->Html->link($this->Time->nice($row->last_run), ['plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'view', $row->last_queued_job_id], ['escapeTitle' => false]) ?>
+						<?php } else { ?>
+							<?= $this->Time->nice($row->last_run) ?>
+						<?php } ?>
+					</td>
 				</tr>
 				<?php
 				$nextRun = $row->next_run ?: $row->calculateNextRun();
@@ -142,12 +148,13 @@
 						<th><?= __('Created') ?></th>
 						<th><?= __('Status') ?></th>
 						<th><?= __('Duration') ?></th>
+						<th><?= __('Actions') ?></th>
 					</tr>
 				</thead>
 				<tbody>
 				<?php foreach ($recentJobs as $job) { ?>
 					<tr>
-						<td><?= $this->Time->nice($job->created) ?></td>
+						<td><?= $this->Html->link($this->Time->nice($job->created), ['plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'view', $job->id], ['escapeTitle' => false]) ?></td>
 						<td>
 							<?php if ($job->completed) { ?>
 								<?php if ($job->failure_message) { ?>
@@ -169,6 +176,9 @@
 							<?php } else { ?>
 								-
 							<?php } ?>
+						</td>
+						<td>
+							<?= $this->Html->link(__('View Job'), ['plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'view', $job->id]) ?>
 						</td>
 					</tr>
 				<?php } ?>


### PR DESCRIPTION
## Summary

- Stores `last_queued_job_id` on scheduler rows when a job is dispatched, enabling one-click navigation from scheduler to the queue job detail view
- Makes "Last Run" timestamps clickable links in dashboard, detail view, and list view — clicking goes directly to the queue job's detail page (output, failure message, memory, duration, etc.)
- Adds "Actions" column with "View Job" links in the recent executions table on the detail view
- New column is nullable — existing systems work without running the migration immediately. Rows created before the migration simply show the timestamp without a link

## Changes

- `config/Migrations/20260129000000_QueueSchedulerJobLink.php`: Adds nullable unsigned integer `last_queued_job_id` column with index
- `src/Model/Entity/SchedulerRow.php`: Added property annotation
- `src/Model/Table/SchedulerRowsTable.php`: Captures created job ID from `createJob()` return value; added to `scaffoldSkipFields`
- `templates/Admin/QueueScheduler/index.php`: Last Run timestamp links to queue job view when `last_queued_job_id` is set
- `templates/Admin/SchedulerRows/index.php`: Same linking for the rows list view
- `templates/Admin/SchedulerRows/view.php`: Last Run links to queue job; recent executions table gets "Actions" column with direct "View Job" links, and created timestamps are also clickable

## Depends on

- Pairs well with dereuromark/cakephp-queue#458 (output capture) — with both PRs, clicking through from the scheduler shows the full captured output of each job execution