### PR TITLE
Add scheduler logging and fix command output capture

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 		"cakephp/cakephp": "^5.1.1",
 		"dragonmantank/cron-expression": "^3.3",
 		"dereuromark/cakephp-tools": "^3.0.0",
-		"dereuromark/cakephp-queue": "^8.3.1"
+		"dereuromark/cakephp-queue": "^8.9.0"
 	},
 	"require-dev": {
 		"panlatent/cron-expression-descriptor": "^1.1.0",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 		"cakephp/cakephp": "^5.1.1",
 		"dragonmantank/cron-expression": "^3.3",
 		"dereuromark/cakephp-tools": "^3.0.0",
-		"dereuromark/cakephp-queue": "^8.1.0"
+		"dereuromark/cakephp-queue": "^8.3.1"
 	},
 	"require-dev": {
 		"panlatent/cron-expression-descriptor": "^1.1.0",

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -5,12 +5,15 @@ namespace QueueScheduler\Command;
 use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
+use Cake\Log\LogTrait;
 use QueueScheduler\Scheduler\Scheduler;
 
 /**
  * Run command.
  */
 class RunCommand extends Command {
+
+	use LogTrait;
 
 	/**
 	 * @return string
@@ -35,8 +38,11 @@ class RunCommand extends Command {
 
 		$io->success('Done: ' . $count . ' events scheduled.');
 		if ($count < $events->count()) {
-			$io->warning($events->count() - $count . ' events held back (run not finished or still pending in queue)');
+			$heldBack = $events->count() - $count;
+			$io->warning($heldBack . ' events held back (run not finished or still pending in queue)');
 		}
+
+		$this->log(sprintf('Scheduler: %d/%d events scheduled', $count, $events->count()), 'info');
 
 		return null;
 	}

--- a/templates/Admin/SchedulerRows/view.php
+++ b/templates/Admin/SchedulerRows/view.php
@@ -148,6 +148,7 @@
 						<th><?= __('Created') ?></th>
 						<th><?= __('Status') ?></th>
 						<th><?= __('Duration') ?></th>
+						<th><?= __('Output') ?></th>
 						<th><?= __('Actions') ?></th>
 					</tr>
 				</thead>
@@ -173,6 +174,21 @@
 								<?= $job->fetched->diffInSeconds($job->completed) ?> <?= __('seconds') ?>
 							<?php } elseif ($job->fetched) { ?>
 								<?= __('In progress...') ?>
+							<?php } else { ?>
+								-
+							<?php } ?>
+						</td>
+						<td>
+							<?php if ($job->output) { ?>
+								<details>
+									<summary><?= __('Show output') ?> (<?= $this->Number->toReadableSize(strlen($job->output)) ?>)</summary>
+									<pre class="job-output"><?= h($job->output) ?></pre>
+								</details>
+							<?php } elseif ($job->failure_message) { ?>
+								<details>
+									<summary class="text-danger"><?= __('Show error') ?></summary>
+									<pre class="job-output"><?= h($job->failure_message) ?></pre>
+								</details>
 							<?php } else { ?>
 								-
 							<?php } ?>

--- a/tests/TestCase/Queue/Task/CommandExecuteTaskTest.php
+++ b/tests/TestCase/Queue/Task/CommandExecuteTaskTest.php
@@ -5,6 +5,8 @@ namespace QueueScheduler\Test\TestCase\Queue\Task;
 use Cake\Console\ConsoleIo;
 use Cake\Console\TestSuite\StubConsoleOutput;
 use Cake\TestSuite\TestCase;
+use Queue\Console\Io;
+use Queue\Model\QueueException;
 use QueueScheduler\Queue\Task\CommandExecuteTask;
 use Tools\Command\InflectCommand;
 
@@ -14,18 +16,36 @@ class CommandExecuteTaskTest extends TestCase {
 	 * @return void
 	 */
 	public function testRun(): void {
-		$task = new CommandExecuteTask();
-
 		$out = new StubConsoleOutput();
 		$err = new StubConsoleOutput();
+		$io = new Io(new ConsoleIo($out, $err));
+		$task = new CommandExecuteTask($io);
+
 		$data = [
 			'class' => InflectCommand::class,
 			'args' => ['Foo', 'pluralize'],
-			'io' => new ConsoleIo($out, $err),
 		];
 		$task->run($data, 0);
 
 		$this->assertTextContains('Foos', $out->output());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRunFailure(): void {
+		$out = new StubConsoleOutput();
+		$err = new StubConsoleOutput();
+		$io = new Io(new ConsoleIo($out, $err));
+		$task = new CommandExecuteTask($io);
+
+		$data = [
+			'class' => InflectCommand::class,
+			'args' => ['--invalid-arg'],
+		];
+
+		$this->expectException(QueueException::class);
+		$task->run($data, 0);
 	}
 
 }

--- a/tests/TestCase/Queue/Task/CommandExecuteTaskTest.php
+++ b/tests/TestCase/Queue/Task/CommandExecuteTaskTest.php
@@ -8,6 +8,7 @@ use Cake\TestSuite\TestCase;
 use Queue\Console\Io;
 use Queue\Model\QueueException;
 use QueueScheduler\Queue\Task\CommandExecuteTask;
+use TestApp\Command\TestOutputCommand;
 use Tools\Command\InflectCommand;
 
 class CommandExecuteTaskTest extends TestCase {
@@ -15,7 +16,7 @@ class CommandExecuteTaskTest extends TestCase {
 	/**
 	 * @return void
 	 */
-	public function testRun(): void {
+	public function testRunStdoutForwarded(): void {
 		$out = new StubConsoleOutput();
 		$err = new StubConsoleOutput();
 		$io = new Io(new ConsoleIo($out, $err));
@@ -33,19 +34,84 @@ class CommandExecuteTaskTest extends TestCase {
 	/**
 	 * @return void
 	 */
-	public function testRunFailure(): void {
+	public function testRunStderrForwarded(): void {
 		$out = new StubConsoleOutput();
 		$err = new StubConsoleOutput();
 		$io = new Io(new ConsoleIo($out, $err));
 		$task = new CommandExecuteTask($io);
 
 		$data = [
-			'class' => InflectCommand::class,
-			'args' => ['--invalid-arg'],
+			'class' => TestOutputCommand::class,
+			'args' => [],
+		];
+		$task->run($data, 0);
+
+		$this->assertTextContains('stderr warning line', $err->output());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRunCombinedOutput(): void {
+		$out = new StubConsoleOutput();
+		$err = new StubConsoleOutput();
+		$io = new Io(new ConsoleIo($out, $err));
+		$task = new CommandExecuteTask($io);
+
+		$data = [
+			'class' => TestOutputCommand::class,
+			'args' => [],
+		];
+		$task->run($data, 0);
+
+		$stdout = $out->output();
+		$this->assertTextContains('stdout line one', $stdout);
+		$this->assertTextContains('stdout line two', $stdout);
+		$this->assertTextContains('stderr warning line', $err->output());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRunFailureThrowsException(): void {
+		$out = new StubConsoleOutput();
+		$err = new StubConsoleOutput();
+		$io = new Io(new ConsoleIo($out, $err));
+		$task = new CommandExecuteTask($io);
+
+		$data = [
+			'class' => TestOutputCommand::class,
+			'args' => ['--fail'],
 		];
 
 		$this->expectException(QueueException::class);
+		$this->expectExceptionMessage('TestOutputCommand');
 		$task->run($data, 0);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRunFailureStillForwardsOutput(): void {
+		$out = new StubConsoleOutput();
+		$err = new StubConsoleOutput();
+		$io = new Io(new ConsoleIo($out, $err));
+		$task = new CommandExecuteTask($io);
+
+		$data = [
+			'class' => TestOutputCommand::class,
+			'args' => ['--fail'],
+		];
+
+		try {
+			$task->run($data, 0);
+		} catch (QueueException) {
+			// Expected
+		}
+
+		// Output should still be forwarded before the exception
+		$this->assertTextContains('stdout line one', $out->output());
+		$this->assertTextContains('stderr warning line', $err->output());
 	}
 
 }

--- a/tests/test_app/src/Command/TestOutputCommand.php
+++ b/tests/test_app/src/Command/TestOutputCommand.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace TestApp\Command;
+
+use Cake\Command\Command;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
+use Cake\Console\ConsoleOptionParser;
+
+/**
+ * Test command that writes to both stdout and stderr.
+ */
+class TestOutputCommand extends Command {
+
+	/**
+	 * @param \Cake\Console\ConsoleOptionParser $parser
+	 * @return \Cake\Console\ConsoleOptionParser
+	 */
+	public function buildOptionParser(ConsoleOptionParser $parser): ConsoleOptionParser {
+		$parser->addOption('fail', [
+			'boolean' => true,
+			'default' => false,
+		]);
+
+		return $parser;
+	}
+
+	/**
+	 * @param \Cake\Console\Arguments $args
+	 * @param \Cake\Console\ConsoleIo $io
+	 * @return int|null
+	 */
+	public function execute(Arguments $args, ConsoleIo $io): ?int {
+		$io->out('stdout line one');
+		$io->out('stdout line two');
+		$io->err('stderr warning line');
+
+		if ($args->getOption('fail')) {
+			return static::CODE_ERROR;
+		}
+
+		return static::CODE_SUCCESS;
+	}
+
+}


### PR DESCRIPTION
## Summary

- **CommandExecuteTask**: Captures command stdout/stderr via `tmpfile()` streams and forwards output through `$this->io`, so the Processor's output capture stores it in the `queued_jobs.output` column. Previously a fresh `ConsoleIo()` was used, bypassing capture entirely for Cake Command type jobs.
- **RunCommand**: Adds `LogTrait` to log scheduling cycle summaries (e.g. `Scheduler: 3/5 events scheduled`) to the configured log.
- **Scheduler backend view**: Shows job output/errors inline in the "Recent Executions" table via expandable `<details>` elements, avoiding the need to navigate to the Queue plugin's job detail page.

## Test plan

- [x] Existing tests pass (20 tests, 37 assertions)
- [ ] Run a Cake Command type scheduler row and verify output now appears in the `output` column
- [ ] Run `bin/cake scheduler run` and check log file for scheduling summary
- [ ] Verify output/error display in the scheduler row view page