### PR TITLE
Add content field autocomplete for available commands and tasks

### DIFF
--- a/src/Controller/Admin/SchedulerRowsController.php
+++ b/src/Controller/Admin/SchedulerRowsController.php
@@ -129,7 +129,12 @@ class SchedulerRowsController extends AppController {
 				return $this->redirect(['action' => 'view', $row->id]);
 			}
 			$this->Flash->error(__('The row could not be saved. Please, try again.'));
+		} else {
+			foreach ($this->request->getQueryParams() as $key => $value) {
+				$row->set($key, $value);
+			}
 		}
+
 		$this->set(compact('row'));
 
 		return null;

--- a/src/Controller/Admin/SchedulerRowsController.php
+++ b/src/Controller/Admin/SchedulerRowsController.php
@@ -126,7 +126,7 @@ class SchedulerRowsController extends AppController {
 			if ($this->SchedulerRows->save($row)) {
 				$this->Flash->success(__('The row has been saved.'));
 
-				return $this->redirect(['action' => 'index']);
+				return $this->redirect(['action' => 'view', $row->id]);
 			}
 			$this->Flash->error(__('The row could not be saved. Please, try again.'));
 		}

--- a/src/Model/Table/SchedulerRowsTable.php
+++ b/src/Model/Table/SchedulerRowsTable.php
@@ -73,7 +73,12 @@ class SchedulerRowsTable extends Table {
 			->scalar('name')
 			->maxLength('name', 140)
 			->requirePresence('name', 'create')
-			->notEmptyString('name');
+			->notEmptyString('name')
+			->add('name', 'unique', [
+				'rule' => 'validateUniqueName',
+				'provider' => 'table',
+				'message' => __('This name is already in use.'),
+			]);
 
 		$validator
 			->notEmptyString('type');
@@ -314,6 +319,27 @@ class SchedulerRowsTable extends Table {
 		$this->saveOrFail($row);
 
 		return true;
+	}
+
+	/**
+	 * @param mixed $value
+	 * @param array $context
+	 *
+	 * @return bool
+	 */
+	public function validateUniqueName(mixed $value, array $context): bool {
+		if (!is_string($value) || !$value) {
+			return false;
+		}
+
+		$query = $this->find()
+			->where(['name' => $value]);
+
+		if (!empty($context['data']['id'])) {
+			$query->where(['id !=' => $context['data']['id']]);
+		}
+
+		return $query->count() === 0;
 	}
 
 	/**

--- a/src/View/Helper/SchedulerHelper.php
+++ b/src/View/Helper/SchedulerHelper.php
@@ -4,6 +4,7 @@ namespace QueueScheduler\View\Helper;
 
 use Cake\View\Helper;
 use Queue\Queue\TaskFinder;
+use QueueScheduler\Model\Entity\SchedulerRow;
 use QueueScheduler\Utility\CommandFinder;
 
 /**
@@ -40,6 +41,33 @@ class SchedulerHelper extends Helper {
 		$html .= '<datalist id="content-queue-tasks">';
 		foreach ($this->availableQueueTasks() as $name => $queueTask) {
 			$html .= '<option value="' . h($queueTask) . '" label="' . h($name) . '">';
+		}
+		$html .= '</datalist>';
+
+		return $html;
+	}
+
+	/**
+	 * Renders datalist element for frequency field autocomplete.
+	 *
+	 * @return string
+	 */
+	public function frequencyDatalist(): string {
+		$html = '<datalist id="frequency-suggestions">';
+		foreach (SchedulerRow::shortcuts() as $shortcut) {
+			$html .= '<option value="' . h($shortcut) . '">';
+		}
+
+		$commonCron = [
+			'*/5 * * * *' => 'Every 5 minutes',
+			'*/15 * * * *' => 'Every 15 minutes',
+			'*/30 * * * *' => 'Every 30 minutes',
+			'0 */2 * * *' => 'Every 2 hours',
+			'0 */6 * * *' => 'Every 6 hours',
+			'0 0 * * 1-5' => 'Weekdays at midnight',
+		];
+		foreach ($commonCron as $expression => $label) {
+			$html .= '<option value="' . h($expression) . '" label="' . h($label) . '">';
 		}
 		$html .= '</datalist>';
 

--- a/src/View/Helper/SchedulerHelper.php
+++ b/src/View/Helper/SchedulerHelper.php
@@ -25,4 +25,25 @@ class SchedulerHelper extends Helper {
 		return (new TaskFinder())->all();
 	}
 
+	/**
+	 * Renders datalist elements for content field autocomplete.
+	 *
+	 * @return string
+	 */
+	public function contentDatalists(): string {
+		$html = '<datalist id="content-commands">';
+		foreach ($this->availableCommands() as $name => $command) {
+			$html .= '<option value="' . h($command) . '" label="' . h($name) . '">';
+		}
+		$html .= '</datalist>';
+
+		$html .= '<datalist id="content-queue-tasks">';
+		foreach ($this->availableQueueTasks() as $name => $queueTask) {
+			$html .= '<option value="' . h($queueTask) . '" label="' . h($name) . '">';
+		}
+		$html .= '</datalist>';
+
+		return $html;
+	}
+
 }

--- a/templates/Admin/SchedulerRows/add.php
+++ b/templates/Admin/SchedulerRows/add.php
@@ -22,9 +22,9 @@
 				<?php
 					echo $this->Form->control('name');
 					echo $this->Form->control('type', ['options' => $row::types()]);
-					echo $this->Form->control('content');
+					echo $this->Form->control('content', ['type' => 'text']);
 					echo $this->Form->control('param');
-					echo $this->Form->control('frequency');
+					echo $this->Form->control('frequency', ['list' => 'frequency-suggestions']);
 					echo $this->Form->control('allow_concurrent');
 
 				echo $this->Form->control('enabled');

--- a/templates/Admin/SchedulerRows/add.php
+++ b/templates/Admin/SchedulerRows/add.php
@@ -13,6 +13,11 @@
 		</ul>
 	</aside>
 	<div class="column-responsive column-80 form large-9 medium-8 columns col-sm-8 col-12">
+		<?php if (!$this->request->getQueryParams()) { ?>
+			<?= $this->element('QueueScheduler.quick_add') ?>
+			<hr>
+		<?php } ?>
+
 		<div class="rows form content">
 			<h2><?= __('Rows') ?></h2>
 

--- a/templates/Admin/SchedulerRows/add.php
+++ b/templates/Admin/SchedulerRows/add.php
@@ -34,6 +34,8 @@
 			<?= $this->Form->end() ?>
 		</div>
 
+		<?php echo $this->element('QueueScheduler.content_autocomplete') ?>
+
 		<hr>
 
 		<?php echo $this->element('QueueScheduler.available')?>

--- a/templates/Admin/SchedulerRows/edit.php
+++ b/templates/Admin/SchedulerRows/edit.php
@@ -27,9 +27,9 @@
 				<?php
 					echo $this->Form->control('name');
 					echo $this->Form->control('type', ['options' => $row::types()]);
-					echo $this->Form->control('content');
+					echo $this->Form->control('content', ['type' => 'text']);
 					echo $this->Form->control('param');
-					echo $this->Form->control('frequency');
+					echo $this->Form->control('frequency', ['list' => 'frequency-suggestions']);
 					echo $this->Form->control('allow_concurrent');
 
 					echo $this->Form->control('enabled');

--- a/templates/Admin/SchedulerRows/edit.php
+++ b/templates/Admin/SchedulerRows/edit.php
@@ -39,6 +39,8 @@
 			<?= $this->Form->end() ?>
 		</div>
 
+		<?php echo $this->element('QueueScheduler.content_autocomplete') ?>
+
 		<hr>
 
 		<?php echo $this->element('QueueScheduler.available')?>

--- a/templates/element/content_autocomplete.php
+++ b/templates/element/content_autocomplete.php
@@ -9,6 +9,7 @@
 $scheduler = $this->Scheduler;
 ?>
 <?= $scheduler->contentDatalists() ?>
+<?= $scheduler->frequencyDatalist() ?>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
 	var typeField = document.getElementById('type');

--- a/templates/element/content_autocomplete.php
+++ b/templates/element/content_autocomplete.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ */
+
+/**
+ * @var \QueueScheduler\View\Helper\SchedulerHelper $scheduler
+ */
+$scheduler = $this->Scheduler;
+?>
+<?= $scheduler->contentDatalists() ?>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+	var typeField = document.getElementById('type');
+	var contentField = document.getElementById('content');
+	if (!typeField || !contentField) {
+		return;
+	}
+
+	var datalistMap = {
+		'0': 'content-queue-tasks',
+		'1': 'content-commands'
+	};
+
+	function updateDatalist() {
+		var listId = datalistMap[typeField.value] || '';
+		contentField.setAttribute('list', listId);
+	}
+
+	typeField.addEventListener('change', updateDatalist);
+	updateDatalist();
+});
+</script>

--- a/templates/element/quick_add.php
+++ b/templates/element/quick_add.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ */
+
+use QueueScheduler\Model\Entity\SchedulerRow;
+
+/**
+ * @var \QueueScheduler\View\Helper\SchedulerHelper $scheduler
+ */
+$scheduler = $this->Scheduler;
+?>
+<div class="card mb-4">
+	<div class="card-header">
+		<a class="text-decoration-none" data-bs-toggle="collapse" href="#quick-add-body" role="button" aria-expanded="false" aria-controls="quick-add-body">
+			<h3 class="mb-0"><?= __('Quick Add') ?> <small>&#9660;</small></h3>
+		</a>
+	</div>
+	<div class="collapse" id="quick-add-body">
+		<div class="card-body">
+			<div class="row">
+				<div class="col-md-6">
+					<h4><?= __('Cake Commands') ?></h4>
+					<div class="list-group">
+						<?php foreach ($scheduler->availableCommands() as $name => $command) { ?>
+							<?= $this->Html->link(
+								h($name) . '<br><small class="text-muted"><code>' . h($command) . '</code></small>',
+								['action' => 'add', '?' => [
+									'type' => SchedulerRow::TYPE_CAKE_COMMAND,
+									'content' => $command,
+									'name' => $name,
+								]],
+								['class' => 'list-group-item list-group-item-action', 'escape' => false],
+							) ?>
+						<?php } ?>
+					</div>
+				</div>
+
+				<div class="col-md-6">
+					<h4><?= __('Queue Tasks') ?></h4>
+					<div class="list-group">
+						<?php foreach ($scheduler->availableQueueTasks() as $name => $queueTask) { ?>
+							<?= $this->Html->link(
+								h($name) . '<br><small class="text-muted"><code>' . h($queueTask) . '</code></small>',
+								['action' => 'add', '?' => [
+									'type' => SchedulerRow::TYPE_QUEUE_TASK,
+									'content' => $queueTask,
+									'name' => $name,
+								]],
+								['class' => 'list-group-item list-group-item-action', 'escape' => false],
+							) ?>
+						<?php } ?>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/tests/TestCase/Model/Table/SchedulerRowsTableTest.php
+++ b/tests/TestCase/Model/Table/SchedulerRowsTableTest.php
@@ -163,6 +163,56 @@ class SchedulerRowsTableTest extends TestCase {
 	/**
 	 * @return void
 	 */
+	public function testValidateUniqueName(): void {
+		$row = $this->SchedulerRows->newEntity([
+			'name' => 'My Unique Task',
+			'type' => SchedulerRow::TYPE_QUEUE_TASK,
+			'frequency' => '@daily',
+			'content' => ExampleTask::class,
+			'enabled' => true,
+		]);
+		$this->SchedulerRows->saveOrFail($row);
+
+		// Fixture name should also fail
+		$fixtureConflict = $this->SchedulerRows->newEntity([
+			'name' => 'Lorem ipsum dolor sit amet',
+			'type' => SchedulerRow::TYPE_QUEUE_TASK,
+			'frequency' => '@daily',
+			'content' => ExampleTask::class,
+			'enabled' => true,
+		]);
+		$expected = ['unique' => 'This name is already in use.'];
+		$this->assertSame($expected, $fixtureConflict->getError('name'));
+
+		// Same name should fail
+		$duplicate = $this->SchedulerRows->newEntity([
+			'name' => 'My Unique Task',
+			'type' => SchedulerRow::TYPE_QUEUE_TASK,
+			'frequency' => '@daily',
+			'content' => ExampleTask::class,
+			'enabled' => true,
+		]);
+		$expected = ['unique' => 'This name is already in use.'];
+		$this->assertSame($expected, $duplicate->getError('name'));
+
+		// Different name should pass
+		$other = $this->SchedulerRows->newEntity([
+			'name' => 'Another Task',
+			'type' => SchedulerRow::TYPE_QUEUE_TASK,
+			'frequency' => '@daily',
+			'content' => ExampleTask::class,
+			'enabled' => true,
+		]);
+		$this->assertSame([], $other->getError('name'));
+
+		// Editing existing row with same name should pass
+		$row = $this->SchedulerRows->patchEntity($row, ['name' => 'My Unique Task']);
+		$this->assertSame([], $row->getError('name'));
+	}
+
+	/**
+	 * @return void
+	 */
 	public function testValidateContent(): void {
 		$data = [
 			'name' => 'n',

--- a/tests/TestCase/View/Helper/SchedulerHelperTest.php
+++ b/tests/TestCase/View/Helper/SchedulerHelperTest.php
@@ -65,4 +65,16 @@ class SchedulerHelperTest extends TestCase {
 		$this->assertSame($queueTasks['Queue.Execute'], ExecuteTask::class);
 	}
 
+	/**
+	 * @return void
+	 */
+	public function testContentDatalists(): void {
+		$result = $this->Scheduler->contentDatalists();
+
+		$this->assertStringContainsString('<datalist id="content-commands">', $result);
+		$this->assertStringContainsString('<datalist id="content-queue-tasks">', $result);
+		$this->assertStringContainsString(h(RunCommand::class), $result);
+		$this->assertStringContainsString(h(ExecuteTask::class), $result);
+	}
+
 }


### PR DESCRIPTION
## Summary

- Adds HTML5 `<datalist>` autocomplete to the content field on add/edit forms
- Suggestions switch automatically based on the selected type (Queue Task → task list, Cake Command → command list)
- Adds `contentDatalists()` method to `SchedulerHelper` and a shared `content_autocomplete` element
- No external JS dependencies — uses native browser datalist support

Refs #1