### PR TITLE
Add standalone admin layout with Bootstrap 5

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -8,9 +8,23 @@ return [
 		'plugins' => [],
 		'allowRaw' => false, // By default, this is only enabled in debug mode for security reasons.
 		'crontabMinimum' => '1 minute', // By default, this should be run as `* * * * *`
+
+		// Admin Layout configuration:
+		// - null (default): Uses 'QueueScheduler.queue_scheduler' isolated Bootstrap 5 layout
+		// - false: Disables plugin layout, uses app's default layout
+		// - string: Uses specified layout (e.g., 'QueueScheduler.queue_scheduler' or custom)
+		'adminLayout' => null,
+
+		// Standalone mode:
+		// - false (default): Extends App\Controller\AppController (inherits app auth, components, config)
+		// - true: Isolated admin that doesn't depend on the host app
+		'standalone' => false,
+
+		// Auto-refresh dashboard (in seconds, 0 = disabled)
+		'dashboardAutoRefresh' => 0,
 	],
 	// Icon configuration for the backend UI (optional, but recommended for better UX)
-	// Without this, the UI will fall back to text-based icons.
+	// Without this, the UI will use Font Awesome icons from CDN when using the standalone layout.
 	'Icon' => [
 		'sets' => [
 			'bs' => BootstrapIcon::class,

--- a/src/Controller/Admin/LoadHelperTrait.php
+++ b/src/Controller/Admin/LoadHelperTrait.php
@@ -20,6 +20,7 @@ trait LoadHelperTrait {
 			'Tools.Format',
 			'Tools.Text',
 			'Tools.Time',
+			'QueueScheduler.Scheduler',
 		];
 		if (Configure::read('Icon.sets')) {
 			$helpers[] = class_exists(IconHelper::class) ? 'Templating.Icon' : 'Tools.Icon';

--- a/src/Controller/Admin/QueueSchedulerAppController.php
+++ b/src/Controller/Admin/QueueSchedulerAppController.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace QueueScheduler\Controller\Admin;
+
+use App\Controller\AppController;
+use Cake\Controller\Controller;
+use Cake\Core\Configure;
+
+/**
+ * QueueSchedulerAppController
+ *
+ * Base controller for QueueScheduler admin.
+ *
+ * By default, extends AppController to inherit app authentication, components, and configuration.
+ * Set `QueueScheduler.standalone` to `true` for an isolated admin that doesn't depend on the host app.
+ */
+class QueueSchedulerAppController extends AppController {
+
+	use LoadHelperTrait;
+
+	/**
+	 * @return void
+	 */
+	public function initialize(): void {
+		if (Configure::read('QueueScheduler.standalone')) {
+			// Standalone mode: skip app's AppController, initialize independently
+			Controller::initialize();
+			$this->loadComponent('Flash');
+		} else {
+			// Default: inherit app's full controller setup
+			parent::initialize();
+		}
+
+		$this->loadHelpers();
+
+		// Layout configuration:
+		// - null (default): Uses 'QueueScheduler.queue_scheduler' isolated Bootstrap 5 layout
+		// - false: Disables plugin layout, uses app's default layout
+		// - string: Uses specified layout (e.g., 'QueueScheduler.queue_scheduler' or custom)
+		$layout = Configure::read('QueueScheduler.adminLayout');
+		if ($layout !== false) {
+			$this->viewBuilder()->setLayout($layout ?: 'QueueScheduler.queue_scheduler');
+		}
+	}
+
+}

--- a/src/Controller/Admin/QueueSchedulerController.php
+++ b/src/Controller/Admin/QueueSchedulerController.php
@@ -7,21 +7,9 @@ use Cron\CronExpression;
 use Exception;
 use Locale;
 use Panlatent\CronExpressionDescriptor\ExpressionDescriptor;
-use QueueScheduler\Controller\AppController;
 use QueueScheduler\Model\Entity\SchedulerRow;
 
-class QueueSchedulerController extends AppController {
-
-	use LoadHelperTrait;
-
-	/**
-	 * @return void
-	 */
-	public function initialize(): void {
-		parent::initialize();
-
-		$this->loadHelpers();
-	}
+class QueueSchedulerController extends QueueSchedulerAppController {
 
 	/**
 	 * Index method

--- a/src/Controller/Admin/SchedulerRowsController.php
+++ b/src/Controller/Admin/SchedulerRowsController.php
@@ -3,7 +3,6 @@
 namespace QueueScheduler\Controller\Admin;
 
 use Cake\Http\Response;
-use QueueScheduler\Controller\AppController;
 
 /**
  * Rows Controller
@@ -11,18 +10,7 @@ use QueueScheduler\Controller\AppController;
  * @method \Cake\Datasource\ResultSetInterface<\QueueScheduler\Model\Entity\SchedulerRow> paginate(\Cake\Datasource\RepositoryInterface|\Cake\Datasource\QueryInterface|string|null $object = null, array $settings = [])
  * @property \QueueScheduler\Model\Table\SchedulerRowsTable $SchedulerRows
  */
-class SchedulerRowsController extends AppController {
-
-	use LoadHelperTrait;
-
-	/**
-	 * @return void
-	 */
-	public function initialize(): void {
-		parent::initialize();
-
-		$this->loadHelpers();
-	}
+class SchedulerRowsController extends QueueSchedulerAppController {
 
 	/**
 	 * Index method

--- a/templates/Admin/QueueScheduler/index.php
+++ b/templates/Admin/QueueScheduler/index.php
@@ -5,96 +5,157 @@
  * @var array<\Queue\Model\Entity\QueuedJob> $runningJobs
  */
 ?>
-<nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">
-	<ul class="side-nav nav nav-pills flex-column">
-		<li class="nav-item heading"><?= __('Actions') ?></li>
-		<li class="nav-item">
-			<?= $this->Html->link(__('New {0}', __('Row')), ['controller' => 'SchedulerRows', 'action' => 'add'], ['class' => 'nav-link']) ?>
-			<?= $this->Html->link(__('Available {0}', __('Intervals')), ['action' => 'intervals'], ['class' => 'nav-link']) ?>
-		</li>
-	</ul>
-</nav>
-<div class="rows index content large-9 medium-8 columns col-sm-8 col-12">
+<div class="scheduler-dashboard">
+	<div class="d-flex justify-content-between align-items-center mb-4">
+		<h2 class="mb-0">
+			<i class="fas fa-calendar-alt me-2"></i><?= __('Queue Scheduler') ?>
+		</h2>
+		<div>
+			<?= $this->Html->link(
+				'<i class="fas fa-plus me-1"></i>' . __('New Schedule'),
+				['controller' => 'SchedulerRows', 'action' => 'add'],
+				['class' => 'btn btn-primary', 'escape' => false],
+			) ?>
+		</div>
+	</div>
 
-	<h2><?= __('Queue Scheduler') ?></h2>
-	<p>Addon to run commands and queue tasks as crontab like database driven schedule.</p>
+	<p class="text-muted mb-4"><?= __('Addon to run commands and queue tasks as crontab like database driven schedule.') ?></p>
 
-	<h3>Current schedule</h3>
-	<table class="table table-sm table-striped">
-		<thead>
-		<tr>
-			<th><?= 'Name' ?></th>
-			<th><?= 'Frequency' ?></th>
-			<th><?= 'Log' ?></th>
-			<th class="actions"><?= __('Actions') ?></th>
-		</tr>
-		</thead>
-		<tbody>
-		<?php foreach ($schedulerRows as $schedulerRow) { ?>
-			<?php
-			$queuedJob = $runningJobs[$schedulerRow->job_reference] ?? null;
-			?>
-			<tr>
-				<td>
-					<?= $this->Html->link($schedulerRow->name, ['controller' => 'SchedulerRows', 'action' => 'view', $schedulerRow->id]) ?>
-					<div>
-						<small><?= $schedulerRow::types($schedulerRow->type) ?></small>
-					</div>
-				</td>
-				<td>
-					<?= h($schedulerRow->frequency) ?>
+	<div class="card">
+		<div class="card-header">
+			<i class="fas fa-clock me-2"></i><?= __('Current Schedule') ?>
+		</div>
+		<div class="card-body p-0">
+			<div class="table-responsive">
+				<table class="table table-hover scheduler-table mb-0">
+					<thead>
+						<tr>
+							<th><?= __('Name') ?></th>
+							<th><?= __('Frequency') ?></th>
+							<th><?= __('Log') ?></th>
+							<th class="actions text-end"><?= __('Actions') ?></th>
+						</tr>
+					</thead>
+					<tbody>
+						<?php foreach ($schedulerRows as $schedulerRow) { ?>
+							<?php
+							$queuedJob = $runningJobs[$schedulerRow->job_reference] ?? null;
+							?>
+							<tr>
+								<td>
+									<?= $this->Html->link(
+										h($schedulerRow->name),
+										['controller' => 'SchedulerRows', 'action' => 'view', $schedulerRow->id],
+										['class' => 'fw-semibold'],
+									) ?>
+									<div>
+										<small class="text-muted"><?= $schedulerRow::types($schedulerRow->type) ?></small>
+									</div>
+								</td>
+								<td>
+									<code><?= h($schedulerRow->frequency) ?></code>
 
-					<?php if ($queuedJob) { ?>
-					<div class="alert alert-warning">
-						<b><?php echo h($queuedJob->status) ?: 'Queued'?></b>
-						<?php echo $this->Html->link($this->element('QueueScheduler.icon', ['name' => 'view']), ['plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'view', $queuedJob->id], ['escapeTitle' => false]); ?>
+									<?php if ($queuedJob) { ?>
+										<div class="alert alert-job-running mt-2 mb-0 p-2">
+											<strong><?= h($queuedJob->status) ?: __('Queued') ?></strong>
+											<?= $this->Html->link(
+												'<i class="fas fa-eye"></i>',
+												['plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'view', $queuedJob->id],
+												['escape' => false, 'class' => 'ms-1'],
+											) ?>
 
-						<?php if (!$queuedJob->completed && $queuedJob->fetched) { ?>
-							<?php if (!$queuedJob->failure_message) { ?>
-								<?php echo $this->QueueProgress->progress($queuedJob) ?>
-								<br>
-								<?php
-								$textProgressBar = $this->QueueProgress->progressBar($queuedJob, 18);
-								echo $this->QueueProgress->htmlProgressBar($queuedJob, $textProgressBar);
-								?>
-							<?php } else { ?>
-								<i><?php echo $this->Queue->failureStatus($queuedJob); ?></i>
-							<?php } ?>
+											<?php if (!$queuedJob->completed && $queuedJob->fetched) { ?>
+												<?php if (!$queuedJob->failure_message) { ?>
+													<div class="mt-1">
+														<?= $this->QueueProgress->progress($queuedJob) ?>
+														<br>
+														<?php
+														$textProgressBar = $this->QueueProgress->progressBar($queuedJob, 18);
+														echo $this->QueueProgress->htmlProgressBar($queuedJob, $textProgressBar);
+														?>
+													</div>
+												<?php } else { ?>
+													<div class="mt-1">
+														<i class="text-danger"><?= $this->Queue->failureStatus($queuedJob) ?></i>
+													</div>
+												<?php } ?>
+											<?php } ?>
+										</div>
+									<?php } ?>
+								</td>
+								<td>
+									<?php if ($schedulerRow->last_run) { ?>
+										<div>
+											<small class="text-muted"><?= __('Last Run') ?>:
+												<?php if ($schedulerRow->last_queued_job_id) { ?>
+													<?= $this->Html->link(
+														$this->Time->nice($schedulerRow->last_run),
+														['plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'view', $schedulerRow->last_queued_job_id],
+														['escapeTitle' => false],
+													) ?>
+												<?php } else { ?>
+													<?= $this->Time->nice($schedulerRow->last_run) ?>
+												<?php } ?>
+											</small>
+										</div>
+									<?php } ?>
+									<?php
+									$nextRun = $schedulerRow->next_run ?: $schedulerRow->calculateNextRun();
+									?>
+									<?php if ($nextRun) { ?>
+										<div>
+											<small class="text-muted"><?= __('Next Run') ?>: <?= $this->Time->nice($nextRun) ?></small>
+										</div>
+									<?php } ?>
+								</td>
+								<td class="actions text-end">
+									<?php if (!$queuedJob) { ?>
+										<?= $this->Form->postLink(
+											'<i class="fas fa-play-circle"></i>',
+											['controller' => 'SchedulerRows', 'action' => 'run', $schedulerRow->id],
+											[
+												'escapeTitle' => false,
+												'class' => 'btn btn-sm btn-success me-1',
+												'title' => __('Run manually now'),
+												'confirm' => __('Sure to run it now?'),
+											],
+										) ?>
+									<?php } ?>
+									<?= $this->Form->postLink(
+										'<i class="fas fa-times"></i>',
+										['controller' => 'SchedulerRows', 'action' => 'edit', $schedulerRow->id],
+										[
+											'data' => ['enabled' => 0],
+											'escapeTitle' => false,
+											'class' => 'btn btn-sm btn-danger',
+											'title' => __('Disable'),
+											'confirm' => __('Sure to disable?'),
+										],
+									) ?>
+								</td>
+							</tr>
 						<?php } ?>
-					</div>
-					<?php } ?>
-				</td>
-				<td>
-					<?php if ($schedulerRow->last_run) { ?>
-						<div><small><?= __('Last Run') ?>:
-							<?php if ($schedulerRow->last_queued_job_id) { ?>
-								<?= $this->Html->link($this->Time->nice($schedulerRow->last_run), ['plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'view', $schedulerRow->last_queued_job_id], ['escapeTitle' => false]) ?>
-							<?php } else { ?>
-								<?= $this->Time->nice($schedulerRow->last_run) ?>
-							<?php } ?>
-						</small></div>
-					<?php } ?>
-					<?php
-						$nextRun = $schedulerRow->next_run ?: $schedulerRow->calculateNextRun();
-					?>
-					<?php if ($nextRun) { ?>
-						<div><small><?= __('Next Run') ?>: <?php echo $this->Time->nice($nextRun); ?></small></div>
-					<?php } ?>
-				</td>
-				<td class="actions">
-					<?php if (!$queuedJob) { ?>
-						<?php echo $this->Form->postLink($this->element('QueueScheduler.icon', ['name' => 'play-circle', 'attributes' => ['title' => 'Run manually now']]), ['controller' => 'SchedulerRows', 'action' => 'run', $schedulerRow->id], ['escapeTitle' => false, 'class' => 'btn btn-small btn-success', 'confirm' => 'Sure to run it now?']); ?>
-					<?php } ?>
-					<?php echo $this->Form->postLink($this->element('QueueScheduler.icon', ['name' => 'no', 'attributes' => ['title' => 'Disable']]), ['controller' => 'SchedulerRows', 'action' => 'edit', $schedulerRow->id], ['data' => ['enabled' => 0], 'escapeTitle' => false, 'class' => 'btn btn-small btn-danger', 'confirm' => 'Sure to disable?']); ?>
-				</td>
-			</tr>
-		<?php } ?>
-		</tbody>
-	</table>
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</div>
 
-
-	<p>
-	<?= $this->Html->link(__('Details'), ['controller' => 'SchedulerRows', 'action' => 'index'], ['class' => 'btn btn-secondary']) ?> <?php echo $this->Form->postLink($this->element('QueueScheduler.icon', ['name' => 'no', 'attributes' => ['title' => 'Disable']]) . ' ' . __('Disable all'), ['controller' => 'SchedulerRows', 'action' => 'disableAll'], ['escapeTitle' => false, 'class' => 'btn btn-small btn-danger', 'block' => true,  'confirm' => 'Sure to disable all?']); ?>
-	</p>
-
+	<div class="mt-3">
+		<?= $this->Html->link(
+			'<i class="fas fa-list me-1"></i>' . __('All Schedules'),
+			['controller' => 'SchedulerRows', 'action' => 'index'],
+			['class' => 'btn btn-secondary me-2', 'escape' => false],
+		) ?>
+		<?= $this->Form->postLink(
+			'<i class="fas fa-times me-1"></i>' . __('Disable All'),
+			['controller' => 'SchedulerRows', 'action' => 'disableAll'],
+			[
+				'escapeTitle' => false,
+				'class' => 'btn btn-danger',
+				'confirm' => __('Sure to disable all?'),
+				'block' => true,
+			],
+		) ?>
+	</div>
 </div>

--- a/templates/Admin/QueueScheduler/intervals.php
+++ b/templates/Admin/QueueScheduler/intervals.php
@@ -5,61 +5,108 @@
  * @var string|null $result
  */
 ?>
-<nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">
-	<ul class="side-nav nav nav-pills flex-column">
-		<li class="nav-item heading"><?= __('Actions') ?></li>
-		<li class="nav-item">
-			<?= $this->Html->link(__('Back'), ['controller' => 'SchedulerRows', 'action' => 'index'], ['class' => 'nav-link']) ?>
-		</li>
-	</ul>
-</nav>
-<div class="rows index content large-9 medium-8 columns col-sm-8 col-12">
-
-	<h1><?= __('Queue Scheduler') ?></h1>
-
-	<h2><?php echo __('Intervals'); ?></h2>
+<div class="scheduler-intervals">
+	<div class="d-flex justify-content-between align-items-center mb-4">
+		<h2 class="mb-0">
+			<i class="fas fa-clock me-2"></i><?= __('Intervals Reference') ?>
+		</h2>
+		<div>
+			<?= $this->Html->link(
+				'<i class="fas fa-arrow-left me-1"></i>' . __('Back'),
+				['controller' => 'SchedulerRows', 'action' => 'index'],
+				['class' => 'btn btn-secondary', 'escape' => false],
+			) ?>
+		</div>
+	</div>
 
 	<div class="row">
-		<div class="col-md-6">
+		<div class="col-lg-6 mb-4">
+			<div class="card h-100">
+				<div class="card-header">
+					<i class="fas fa-hashtag me-2"></i><?= __('Cron Shortcuts') ?>
+				</div>
+				<div class="card-body">
+					<ul class="list-unstyled mb-0">
+						<?php foreach ($shortcuts as $shortcut) { ?>
+							<li class="mb-2">
+								<?php
+								$cronExpression = $shortcut === '@minutely' ? '* * * * *' : $shortcut;
+								$expression = new \Cron\CronExpression($cronExpression);
+								?>
+								<code><?= $expression ?></code> as <code><?= h($shortcut) ?></code>
+							</li>
+						<?php } ?>
+					</ul>
+				</div>
+			</div>
+		</div>
 
-	<h3><?php echo __('Shortcuts available'); ?></h3>
-	<ul>
-		<?php foreach ($shortcuts as $shortcut) { ?>
-			<li>
-				<p>
-					<?php
-					$cronExpression = $shortcut === '@minutely' ? '* * * * *' : $shortcut;
-					?>
-					<code><?php echo $expression = (new \Cron\CronExpression($cronExpression));?></code> as <code><?php echo h($shortcut); ?></code> shortcut
-				</p>
-			</li>
-		<?php } ?>
-	</ul>
+		<div class="col-lg-6 mb-4">
+			<div class="card h-100">
+				<div class="card-header">
+					<i class="fas fa-language me-2"></i><?= __('Translate Expression') ?>
+				</div>
+				<div class="card-body">
+					<?php if (class_exists('Panlatent\CronExpressionDescriptor\ExpressionDescriptor')) { ?>
+						<?= $this->Form->create() ?>
+						<div class="mb-3">
+							<?= $this->Form->control('interval', [
+								'label' => __('Cron Expression'),
+								'placeholder' => '* * * * *',
+								'class' => 'form-control',
+							]) ?>
+						</div>
+						<?= $this->Form->button(__('Translate'), ['class' => 'btn btn-primary']) ?>
+						<?= $this->Form->end() ?>
 
-	<h3>DateInterval style</h3>
-	<p>
-	They either start with a `P` or a `+`. Other values are invalid.
-	</p>
-	<ul>
-		<li>
-			<p><code>P1D</code> or <code>+ 1 day</code></p>
-		</li>
-		<li>
-			<p><code>P2W</code> or <code>+ 2 weeks</code></p>
-		</li>
-	</ul>
-	<p>
-	You can also define more complex intervals by chaining: <code>+ 1 hour + 5 minutes</code>.
-	</p>
-	<p>
-	See <a href="https://www.php.net/manual/en/dateinterval.createfromdatestring.php" target="_blank">php.net/manual/en/dateinterval.createfromdatestring.php</a>for details.
-	</p>
+						<?php if (!empty($result)) { ?>
+							<div class="alert alert-success mt-3 mb-0">
+								<strong><?= __('Result') ?>:</strong> <?= h($result) ?>
+							</div>
+						<?php } ?>
+					<?php } else { ?>
+						<div class="alert alert-info mb-0">
+							<i class="fas fa-info-circle me-1"></i>
+							<?= __('Requires {0} to be installed.', '<code>panlatent/cron-expression-descriptor</code>') ?>
+						</div>
+					<?php } ?>
+				</div>
+			</div>
+		</div>
+	</div>
 
-	<h3>Crontab style</h3>
+	<div class="row">
+		<div class="col-lg-6 mb-4">
+			<div class="card h-100">
+				<div class="card-header">
+					<i class="fas fa-calendar-day me-2"></i><?= __('DateInterval Style') ?>
+				</div>
+				<div class="card-body">
+					<p><?= __('They either start with a {0} or a {1}. Other values are invalid.', '<code>P</code>', '<code>+</code>') ?></p>
+					<ul class="mb-3">
+						<li><code>P1D</code> or <code>+ 1 day</code></li>
+						<li><code>P2W</code> or <code>+ 2 weeks</code></li>
+					</ul>
+					<p class="mb-2"><?= __('You can also define more complex intervals by chaining:') ?></p>
+					<code>+ 1 hour + 5 minutes</code>
+					<p class="mt-3 mb-0">
+						<a href="https://www.php.net/manual/en/dateinterval.createfromdatestring.php" target="_blank" class="btn btn-sm btn-outline-secondary">
+							<i class="fas fa-external-link-alt me-1"></i><?= __('PHP Documentation') ?>
+						</a>
+					</p>
+				</div>
+			</div>
+		</div>
 
-<pre>*    *    *    *    *   /path/to/somecommand.sh
+		<div class="col-lg-6 mb-4">
+			<div class="card h-100">
+				<div class="card-header">
+					<i class="fas fa-terminal me-2"></i><?= __('Crontab Style') ?>
+				</div>
+				<div class="card-body">
+					<pre class="mb-3">*    *    *    *    *   /path/to/command
 |    |    |    |    |            |
-|    |    |    |    |    Command or Script to execute
+|    |    |    |    |    Command or Script
 |    |    |    |    |
 |    |    |    | Day of week(0-6 | Sun-Sat)
 |    |    |    |
@@ -70,36 +117,11 @@
 |   Hour(0-23)
 |
 Min(0-59)</pre>
-	<p>See <a href="https://crontab.guru/" target="_blank">crontab.guru/</a> for details.</p>
-
-		</div>
-
-		<div class="col-md-6">
-			<h3>Translate</h3>
-
-			<?php if (class_exists('Panlatent\CronExpressionDescriptor\ExpressionDescriptor')) { ?>
-
-			<?php echo $this->Form->create();?>
-			<fieldset>
-				<legend><?php echo __('Crontab');?></legend>
-				<?php
-				echo $this->Form->control('interval');
-				?>
-			</fieldset>
-			<?php
-			echo $this->Form->submit(__('Translate'));
-			echo $this->Form->end();
-			?>
-
-			<?php if (!empty($result)) { ?>
-			<b><?php echo __('Result'); ?>: </b>
-				<?php echo h($result); ?>
-			<?php } ?>
-
-			<?php } else { ?>
-				<i>Requires <code>panlatent/cron-expression-descriptor</code> to be installed.</i>
-			<?php } ?>
+					<a href="https://crontab.guru/" target="_blank" class="btn btn-sm btn-outline-secondary">
+						<i class="fas fa-external-link-alt me-1"></i>crontab.guru
+					</a>
+				</div>
+			</div>
 		</div>
 	</div>
-
 </div>

--- a/templates/Admin/SchedulerRows/add.php
+++ b/templates/Admin/SchedulerRows/add.php
@@ -4,45 +4,79 @@
  * @var \QueueScheduler\Model\Entity\SchedulerRow $row
  */
 ?>
-<div class="row">
-	<aside class="column large-3 medium-4 columns col-sm-4 col-12">
-		<ul class="side-nav nav nav-pills flex-column">
-			<li class="nav-item heading"><?= __('Actions') ?></li>
-			<li class="nav-item"><?= $this->Html->link(__('List Rows'), ['action' => 'index'], ['class' => 'nav-link']) ?></li>
-			<li class="nav-item"><?= $this->Html->link(__('Available {0}', __('Intervals')), ['controller' => 'QueueScheduler', 'action' => 'intervals'], ['class' => 'nav-link']) ?></li>
-		</ul>
-	</aside>
-	<div class="column-responsive column-80 form large-9 medium-8 columns col-sm-8 col-12">
-		<?php if (!$this->request->getQueryParams()) { ?>
-			<?= $this->element('QueueScheduler.quick_add') ?>
-			<hr>
-		<?php } ?>
+<div class="scheduler-rows-add">
+	<div class="d-flex justify-content-between align-items-center mb-4">
+		<h2 class="mb-0">
+			<i class="fas fa-plus me-2"></i><?= __('Add Schedule') ?>
+		</h2>
+		<div>
+			<?= $this->Html->link(
+				'<i class="fas fa-arrow-left me-1"></i>' . __('Back'),
+				['action' => 'index'],
+				['class' => 'btn btn-secondary me-2', 'escape' => false],
+			) ?>
+			<?= $this->Html->link(
+				'<i class="fas fa-clock me-1"></i>' . __('Intervals Help'),
+				['controller' => 'QueueScheduler', 'action' => 'intervals'],
+				['class' => 'btn btn-outline-secondary', 'escape' => false],
+			) ?>
+		</div>
+	</div>
 
-		<div class="rows form content">
-			<h2><?= __('Rows') ?></h2>
+	<?php if (!$this->request->getQueryParams()) { ?>
+		<?= $this->element('QueueScheduler.quick_add') ?>
+	<?php } ?>
 
+	<div class="card">
+		<div class="card-header">
+			<i class="fas fa-edit me-2"></i><?= __('Schedule Details') ?>
+		</div>
+		<div class="card-body">
 			<?= $this->Form->create($row) ?>
-			<fieldset>
-				<legend><?= __('Add Row') ?></legend>
-				<?php
-					echo $this->Form->control('name');
-					echo $this->Form->control('type', ['options' => $row::types()]);
-					echo $this->Form->control('content', ['type' => 'text']);
-					echo $this->Form->control('param');
-					echo $this->Form->control('frequency', ['list' => 'frequency-suggestions']);
-					echo $this->Form->control('allow_concurrent');
-
-				echo $this->Form->control('enabled');
-				?>
-			</fieldset>
-			<?= $this->Form->button(__('Submit')) ?>
+			<div class="row">
+				<div class="col-md-6 mb-3">
+					<?= $this->Form->control('name', ['class' => 'form-control']) ?>
+				</div>
+				<div class="col-md-6 mb-3">
+					<?= $this->Form->control('type', ['options' => $row::types(), 'class' => 'form-select']) ?>
+				</div>
+			</div>
+			<div class="mb-3">
+				<?= $this->Form->control('content', ['type' => 'text', 'class' => 'form-control']) ?>
+			</div>
+			<div class="mb-3">
+				<?= $this->Form->control('param', ['class' => 'form-control']) ?>
+			</div>
+			<div class="row">
+				<div class="col-md-6 mb-3">
+					<?= $this->Form->control('frequency', ['list' => 'frequency-suggestions', 'class' => 'form-control']) ?>
+				</div>
+				<div class="col-md-3 mb-3">
+					<?= $this->Form->control('allow_concurrent', ['class' => 'form-check-input']) ?>
+				</div>
+				<div class="col-md-3 mb-3">
+					<?= $this->Form->control('enabled', ['class' => 'form-check-input']) ?>
+				</div>
+			</div>
+			<div class="mt-3">
+				<?= $this->Form->button('<i class="fas fa-save me-1"></i>' . __('Save'), ['class' => 'btn btn-primary', 'escapeTitle' => false]) ?>
+			</div>
 			<?= $this->Form->end() ?>
 		</div>
+	</div>
 
-		<?php echo $this->element('QueueScheduler.content_autocomplete') ?>
+	<?= $this->element('QueueScheduler.content_autocomplete') ?>
 
-		<hr>
-
-		<?php echo $this->element('QueueScheduler.available')?>
+	<div class="card mt-4">
+		<div class="card-header">
+			<a class="text-decoration-none" data-bs-toggle="collapse" href="#available-content" role="button" aria-expanded="false" aria-controls="available-content">
+				<i class="fas fa-list me-2"></i><?= __('Available Commands & Tasks') ?> <small>&#9660;</small>
+			</a>
+		</div>
+		<div class="collapse" id="available-content">
+			<div class="card-body">
+				<?= $this->element('QueueScheduler.available') ?>
+			</div>
+		</div>
 	</div>
 </div>

--- a/templates/Admin/SchedulerRows/add.php
+++ b/templates/Admin/SchedulerRows/add.php
@@ -67,16 +67,18 @@
 
 	<?= $this->element('QueueScheduler.content_autocomplete') ?>
 
-	<div class="card mt-4">
-		<div class="card-header">
-			<a class="text-decoration-none" data-bs-toggle="collapse" href="#available-content" role="button" aria-expanded="false" aria-controls="available-content">
-				<i class="fas fa-list me-2"></i><?= __('Available Commands & Tasks') ?> <small>&#9660;</small>
-			</a>
-		</div>
-		<div class="collapse" id="available-content">
-			<div class="card-body">
-				<?= $this->element('QueueScheduler.available') ?>
+	<?php if ($this->request->getQueryParams()) { ?>
+		<div class="card mt-4">
+			<div class="card-header">
+				<a class="text-decoration-none" data-bs-toggle="collapse" href="#available-content" role="button" aria-expanded="false" aria-controls="available-content">
+					<i class="fas fa-list me-2"></i><?= __('Available Commands & Tasks') ?> <small>&#9660;</small>
+				</a>
+			</div>
+			<div class="collapse" id="available-content">
+				<div class="card-body">
+					<?= $this->element('QueueScheduler.available') ?>
+				</div>
 			</div>
 		</div>
-	</div>
+	<?php } ?>
 </div>

--- a/templates/Admin/SchedulerRows/edit.php
+++ b/templates/Admin/SchedulerRows/edit.php
@@ -4,45 +4,80 @@
  * @var \QueueScheduler\Model\Entity\SchedulerRow $row
  */
 ?>
-<div class="row">
-	<aside class="column large-3 medium-4 columns col-sm-4 col-12">
-		<ul class="side-nav nav nav-pills flex-column">
-			<li class="nav-item heading"><?= __('Actions') ?></li>
-			<li class="nav-item"><?= $this->Form->postLink(
-				__('Delete'),
+<div class="scheduler-rows-edit">
+	<div class="d-flex justify-content-between align-items-center mb-4">
+		<h2 class="mb-0">
+			<i class="fas fa-edit me-2"></i><?= __('Edit Schedule') ?>
+		</h2>
+		<div>
+			<?= $this->Html->link(
+				'<i class="fas fa-arrow-left me-1"></i>' . __('Back'),
+				['action' => 'index'],
+				['class' => 'btn btn-secondary me-2', 'escape' => false],
+			) ?>
+			<?= $this->Form->postLink(
+				'<i class="fas fa-trash me-1"></i>' . __('Delete'),
 				['action' => 'delete', $row->id],
-				['confirm' => __('Are you sure you want to delete # {0}?', $row->id), 'class' => 'nav-link']
-				) ?></li>
-			<li class="nav-item"><?= $this->Html->link(__('List Rows'), ['action' => 'index'], ['class' => 'nav-link']) ?></li>
-			<li><?= $this->Html->link(__('Available {0}', __('Intervals')), ['controller' => 'QueueScheduler', 'action' => 'intervals'], ['class' => 'nav-link']) ?></li>
-		</ul>
-	</aside>
-	<div class="column-responsive column-80 form large-9 medium-8 columns col-sm-8 col-12">
-		<div class="rows form content">
-			<h2><?= __('Rows') ?></h2>
+				['class' => 'btn btn-danger me-2', 'escape' => false, 'confirm' => __('Are you sure you want to delete # {0}?', $row->id)],
+			) ?>
+			<?= $this->Html->link(
+				'<i class="fas fa-clock me-1"></i>' . __('Intervals Help'),
+				['controller' => 'QueueScheduler', 'action' => 'intervals'],
+				['class' => 'btn btn-outline-secondary', 'escape' => false],
+			) ?>
+		</div>
+	</div>
 
+	<div class="card">
+		<div class="card-header">
+			<i class="fas fa-cog me-2"></i><?= __('Schedule Details') ?>
+		</div>
+		<div class="card-body">
 			<?= $this->Form->create($row) ?>
-			<fieldset>
-				<legend><?= __('Edit Row') ?></legend>
-				<?php
-					echo $this->Form->control('name');
-					echo $this->Form->control('type', ['options' => $row::types()]);
-					echo $this->Form->control('content', ['type' => 'text']);
-					echo $this->Form->control('param');
-					echo $this->Form->control('frequency', ['list' => 'frequency-suggestions']);
-					echo $this->Form->control('allow_concurrent');
-
-					echo $this->Form->control('enabled');
-				?>
-			</fieldset>
-			<?= $this->Form->button(__('Submit')) ?>
+			<div class="row">
+				<div class="col-md-6 mb-3">
+					<?= $this->Form->control('name', ['class' => 'form-control']) ?>
+				</div>
+				<div class="col-md-6 mb-3">
+					<?= $this->Form->control('type', ['options' => $row::types(), 'class' => 'form-select']) ?>
+				</div>
+			</div>
+			<div class="mb-3">
+				<?= $this->Form->control('content', ['type' => 'text', 'class' => 'form-control']) ?>
+			</div>
+			<div class="mb-3">
+				<?= $this->Form->control('param', ['class' => 'form-control']) ?>
+			</div>
+			<div class="row">
+				<div class="col-md-6 mb-3">
+					<?= $this->Form->control('frequency', ['list' => 'frequency-suggestions', 'class' => 'form-control']) ?>
+				</div>
+				<div class="col-md-3 mb-3">
+					<?= $this->Form->control('allow_concurrent', ['class' => 'form-check-input']) ?>
+				</div>
+				<div class="col-md-3 mb-3">
+					<?= $this->Form->control('enabled', ['class' => 'form-check-input']) ?>
+				</div>
+			</div>
+			<div class="mt-3">
+				<?= $this->Form->button('<i class="fas fa-save me-1"></i>' . __('Save'), ['class' => 'btn btn-primary', 'escapeTitle' => false]) ?>
+			</div>
 			<?= $this->Form->end() ?>
 		</div>
+	</div>
 
-		<?php echo $this->element('QueueScheduler.content_autocomplete') ?>
+	<?= $this->element('QueueScheduler.content_autocomplete') ?>
 
-		<hr>
-
-		<?php echo $this->element('QueueScheduler.available')?>
+	<div class="card mt-4">
+		<div class="card-header">
+			<a class="text-decoration-none" data-bs-toggle="collapse" href="#available-content" role="button" aria-expanded="false" aria-controls="available-content">
+				<i class="fas fa-list me-2"></i><?= __('Available Commands & Tasks') ?> <small>&#9660;</small>
+			</a>
+		</div>
+		<div class="collapse" id="available-content">
+			<div class="card-body">
+				<?= $this->element('QueueScheduler.available') ?>
+			</div>
+		</div>
 	</div>
 </div>

--- a/templates/Admin/SchedulerRows/index.php
+++ b/templates/Admin/SchedulerRows/index.php
@@ -4,106 +4,146 @@
  * @var iterable<\QueueScheduler\Model\Entity\SchedulerRow> $rows
  */
 ?>
-<nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">
-	<ul class="side-nav nav nav-pills flex-column">
-		<li class="nav-item heading"><?= __('Actions') ?></li>
-		<li class="nav-item">
-			<?= $this->Html->link(__('Dashboard'), ['controller' => 'QueueScheduler', 'action' => 'index'], ['class' => 'nav-link']) ?>
-		</li>
-		<li class="nav-item">
-			<?= $this->Html->link(__('New {0}', __('Row')), ['action' => 'add'], ['class' => 'nav-link']) ?>
-		</li>
-	</ul>
-</nav>
-<div class="rows index content large-9 medium-8 columns col-sm-8 col-12">
-
-	<h2><?= __('Rows') ?></h2>
-
-	<div class="">
-		<table class="table table-sm table-striped">
-			<thead>
-				<tr>
-					<th><?= $this->Paginator->sort('name') ?></th>
-					<th><?= $this->Paginator->sort('type') ?></th>
-					<th><?= $this->Paginator->sort('frequency') ?></th>
-					<th><?= $this->Paginator->sort('allow_concurrent') ?></th>
-					<th><?= $this->Paginator->sort('enabled') ?></th>
-					<th><?= $this->Paginator->sort('created', null, ['direction' => 'desc']) ?></th>
-					<th><?= $this->Paginator->sort('modified', null, ['direction' => 'desc']) ?></th>
-					<th class="actions"><?= __('Actions') ?></th>
-				</tr>
-			</thead>
-			<tbody>
-				<?php foreach ($rows as $row): ?>
-				<tr>
-					<td>
-						<?= h($row->name) ?>
-						<div>
-							<small><?php echo h($row->content);?></small>
-						</div>
-					</td>
-					<td>
-						<?= $row::types($row->type) ?>
-						<div><small>
-                            <?php echo h($row->param); ?>
-						</small></div>
-					</td>
-					<td>
-						<?= h($row->frequency) ?>
-						<?php if (class_exists('Cron\CronExpression') && $row->isCronExpression()) { ?>
-							<?php if (class_exists('Panlatent\CronExpressionDescriptor\ExpressionDescriptor') && $row->isCronExpression()) { ?>
-								<div><small>
-									<?php
-									$expression = (new \Cron\CronExpression($row->frequency));
-									$locale = Locale::getDefault();
-									?>
-									<?php echo (new \Panlatent\CronExpressionDescriptor\ExpressionDescriptor($expression, $locale, true))->getDescription();?>
-								</small></div>
-							<?php } ?>
-						<?php } ?>
-					</td>
-					<td><?= $this->element('QueueScheduler.yes_no', ['value' => $row->allow_concurrent]) ?></td>
-					<td>
-						<?= $this->element('QueueScheduler.yes_no', ['value' => $row->enabled]) ?>
-						<?php if ($row->enabled && $row->type === $row::TYPE_SHELL_COMMAND && !\Cake\Core\Configure::read('QueueScheduler.allowRaw')) { ?>
-							<span><?php echo $this->element('QueueScheduler.icon', ['name' => 'stop-circle', 'attributes' => ['title' => 'Raw commands are currently configured to be not runnable on non-debug system for security reasons.']]); ?></span>
-						<?php } elseif (!$row->enabled && !($row->type === $row::TYPE_SHELL_COMMAND && !\Cake\Core\Configure::read('QueueScheduler.allowRaw'))) { ?>
-							<?php echo $this->Form->postLink($this->element('QueueScheduler.icon', ['name' => 'yes', 'attributes' => ['title' => 'Enable']]) . ' ' . __('Enable'), ['controller' => 'SchedulerRows', 'action' => 'edit', $row->id], ['data' => ['enabled' => 1], 'escapeTitle' => false, 'class' => 'btn btn-small btn-success', 'confirm' => 'Sure to enable?']); ?>
-						<?php } ?>
-
-						<?php if ($row->last_run) { ?>
-						<div><small><?= __('Last Run') ?>:
-							<?php if ($row->last_queued_job_id) { ?>
-								<?= $this->Html->link($this->Time->nice($row->last_run), ['plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'view', $row->last_queued_job_id], ['escapeTitle' => false]) ?>
-							<?php } else { ?>
-								<?= $this->Time->nice($row->last_run) ?>
-							<?php } ?>
-						</small></div>
-						<?php } ?>
-						<?php
-							$nextRun = $row->next_run ?: $row->calculateNextRun();
-						?>
-						<?php if ($nextRun) { ?>
-							<?php if (!$row->enabled) { ?>
-								<div class="canceled"><small><del><?= __('Next Run') ?>: <?php echo $this->Time->nice($nextRun); ?></del></small></div>
-							<?php } else { ?>
-								<div><small><?= __('Next Run') ?>: <?php echo $this->Time->nice($nextRun); ?></small></div>
-							<?php } ?>
-						<?php } ?>
-					</td>
-					<td><?= $this->Time->nice($row->created) ?></td>
-					<td><?= $this->Time->nice($row->modified) ?></td>
-					<td class="actions">
-						<?php echo $this->Html->link($this->element('QueueScheduler.icon', ['name' => 'view']), ['action' => 'view', $row->id], ['escapeTitle' => false]); ?>
-						<?php echo $this->Html->link($this->element('QueueScheduler.icon', ['name' => 'edit']), ['action' => 'edit', $row->id], ['escapeTitle' => false]); ?>
-						<?php echo $this->Form->postLink($this->element('QueueScheduler.icon', ['name' => 'play-circle', 'attributes' => ['title' => 'Run manually now']]), ['action' => 'run', $row->id], ['escapeTitle' => false, 'class' => '', 'confirm' => 'Sure to run it now?']); ?>
-					<?php echo $this->Form->postLink($this->element('QueueScheduler.icon', ['name' => 'delete']), ['action' => 'delete', $row->id], ['escapeTitle' => false, 'confirm' => __('Are you sure you want to delete # {0}?', $row->id)]); ?>
-					</td>
-				</tr>
-				<?php endforeach; ?>
-			</tbody>
-		</table>
+<div class="scheduler-rows-index">
+	<div class="d-flex justify-content-between align-items-center mb-4">
+		<h2 class="mb-0">
+			<i class="fas fa-list me-2"></i><?= __('All Schedules') ?>
+		</h2>
+		<div>
+			<?= $this->Html->link(
+				'<i class="fas fa-plus me-1"></i>' . __('New Schedule'),
+				['action' => 'add'],
+				['class' => 'btn btn-primary', 'escape' => false],
+			) ?>
+		</div>
 	</div>
 
-	<?php echo $this->element('Tools.pagination'); ?>
+	<div class="card">
+		<div class="card-body p-0">
+			<div class="table-responsive">
+				<table class="table table-hover scheduler-table mb-0">
+					<thead>
+						<tr>
+							<th><?= $this->Paginator->sort('name') ?></th>
+							<th><?= $this->Paginator->sort('type') ?></th>
+							<th><?= $this->Paginator->sort('frequency') ?></th>
+							<th><?= $this->Paginator->sort('allow_concurrent') ?></th>
+							<th><?= $this->Paginator->sort('enabled') ?></th>
+							<th><?= $this->Paginator->sort('created', null, ['direction' => 'desc']) ?></th>
+							<th><?= $this->Paginator->sort('modified', null, ['direction' => 'desc']) ?></th>
+							<th class="actions text-end"><?= __('Actions') ?></th>
+						</tr>
+					</thead>
+					<tbody>
+						<?php foreach ($rows as $row) { ?>
+							<tr>
+								<td>
+									<?= h($row->name) ?>
+									<div>
+										<small class="text-muted"><?= h($row->content) ?></small>
+									</div>
+								</td>
+								<td>
+									<?= $row::types($row->type) ?>
+									<?php if ($row->param) { ?>
+										<div><small class="text-muted"><?= h($row->param) ?></small></div>
+									<?php } ?>
+								</td>
+								<td>
+									<code><?= h($row->frequency) ?></code>
+									<?php if (class_exists('Cron\CronExpression') && $row->isCronExpression()) { ?>
+										<?php if (class_exists('Panlatent\CronExpressionDescriptor\ExpressionDescriptor')) { ?>
+											<div>
+												<small class="text-muted">
+													<?php
+													$expression = new \Cron\CronExpression($row->frequency);
+													$locale = Locale::getDefault();
+													echo (new \Panlatent\CronExpressionDescriptor\ExpressionDescriptor($expression, $locale, true))->getDescription();
+													?>
+												</small>
+											</div>
+										<?php } ?>
+									<?php } ?>
+								</td>
+								<td><?= $this->element('QueueScheduler.yes_no', ['value' => $row->allow_concurrent]) ?></td>
+								<td>
+									<?= $this->element('QueueScheduler.yes_no', ['value' => $row->enabled]) ?>
+									<?php if ($row->enabled && $row->type === $row::TYPE_SHELL_COMMAND && !\Cake\Core\Configure::read('QueueScheduler.allowRaw')) { ?>
+										<span class="text-warning" title="<?= __('Raw commands are currently configured to be not runnable on non-debug system for security reasons.') ?>">
+											<i class="fas fa-exclamation-triangle"></i>
+										</span>
+									<?php } elseif (!$row->enabled && !($row->type === $row::TYPE_SHELL_COMMAND && !\Cake\Core\Configure::read('QueueScheduler.allowRaw'))) { ?>
+										<?= $this->Form->postLink(
+											'<i class="fas fa-check me-1"></i>' . __('Enable'),
+											['action' => 'edit', $row->id],
+											[
+												'data' => ['enabled' => 1],
+												'escapeTitle' => false,
+												'class' => 'btn btn-sm btn-success',
+												'confirm' => __('Sure to enable?'),
+											],
+										) ?>
+									<?php } ?>
+
+									<?php if ($row->last_run) { ?>
+										<div>
+											<small class="text-muted"><?= __('Last Run') ?>:
+												<?php if ($row->last_queued_job_id) { ?>
+													<?= $this->Html->link(
+														$this->Time->nice($row->last_run),
+														['plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'view', $row->last_queued_job_id],
+														['escapeTitle' => false],
+													) ?>
+												<?php } else { ?>
+													<?= $this->Time->nice($row->last_run) ?>
+												<?php } ?>
+											</small>
+										</div>
+									<?php } ?>
+									<?php
+									$nextRun = $row->next_run ?: $row->calculateNextRun();
+									?>
+									<?php if ($nextRun) { ?>
+										<?php if (!$row->enabled) { ?>
+											<div><small class="next-run-canceled"><?= __('Next Run') ?>: <?= $this->Time->nice($nextRun) ?></small></div>
+										<?php } else { ?>
+											<div><small class="text-muted"><?= __('Next Run') ?>: <?= $this->Time->nice($nextRun) ?></small></div>
+										<?php } ?>
+									<?php } ?>
+								</td>
+								<td><small><?= $this->Time->nice($row->created) ?></small></td>
+								<td><small><?= $this->Time->nice($row->modified) ?></small></td>
+								<td class="actions text-end">
+									<?= $this->Html->link(
+										'<i class="fas fa-eye"></i>',
+										['action' => 'view', $row->id],
+										['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-secondary me-1', 'title' => __('View')],
+									) ?>
+									<?= $this->Html->link(
+										'<i class="fas fa-edit"></i>',
+										['action' => 'edit', $row->id],
+										['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-secondary me-1', 'title' => __('Edit')],
+									) ?>
+									<?= $this->Form->postLink(
+										'<i class="fas fa-play-circle"></i>',
+										['action' => 'run', $row->id],
+										['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-success me-1', 'title' => __('Run manually now'), 'confirm' => __('Sure to run it now?')],
+									) ?>
+									<?= $this->Form->postLink(
+										'<i class="fas fa-trash"></i>',
+										['action' => 'delete', $row->id],
+										['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-danger', 'title' => __('Delete'), 'confirm' => __('Are you sure you want to delete # {0}?', $row->id)],
+									) ?>
+								</td>
+							</tr>
+						<?php } ?>
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</div>
+
+	<div class="mt-3">
+		<?= $this->element('Tools.pagination') ?>
+	</div>
 </div>

--- a/templates/Admin/SchedulerRows/view.php
+++ b/templates/Admin/SchedulerRows/view.php
@@ -6,213 +6,300 @@
  * @var array<\Queue\Model\Entity\QueuedJob> $recentJobs
  */
 ?>
-<div class="row">
-	<aside class="column actions large-3 medium-4 col-sm-4 col-xs-12">
-		<ul class="side-nav nav nav-pills flex-column">
-			<li class="nav-item heading"><?= __('Actions') ?></li>
-			<li class="nav-item"><?= $this->Html->link(__('Edit {0}', __('Row')), ['action' => 'edit', $row->id], ['class' => 'nav-link']) ?></li>
-			<li class="nav-item"><?= $this->Form->postLink(__('Run {0}', __('manually')), ['action' => 'run', $row->id], ['confirm' => __('Are you sure you want to run this now?'), 'class' => 'nav-link']) ?></li>
-			<li class="nav-item"><?= $this->Form->postLink(__('Delete {0}', __('Row')), ['action' => 'delete', $row->id], ['confirm' => __('Are you sure you want to delete # {0}?', $row->id), 'class' => 'nav-link']) ?></li>
-			<li class="nav-item"><?= $this->Html->link(__('List {0}', __('Rows')), ['action' => 'index'], ['class' => 'nav-link']) ?></li>
-			<li class="nav-item"><?= $this->Html->link(__('View Jobs in Queue'), ['plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'index', '?' => ['search' => $row->job_reference]], ['class' => 'nav-link']) ?></li>
-		</ul>
-	</aside>
-	<div class="column-responsive column-80 content large-9 medium-8 col-sm-8 col-xs-12">
-		<div class="rows view content">
-			<h2><?= h($row->name) ?></h2>
-
-			<table class="table table-striped">
-				<tr>
-					<th><?= __('Type') ?></th>
-					<td><?= $row::types($row->type) ?></td>
-				</tr>
-				<?php if ($row->config) { ?>
-				<tr>
-					<th><?= __('Config') ?></th>
-					<td><pre><?= json_encode(json_decode($row->param, true), JSON_PRETTY_PRINT) ?></pre></td>
-				</tr>
-				<?php } ?>
-				<tr>
-					<th><?= __('Frequency') ?></th>
-					<td>
-						<p>
-						<code><?= h($row->frequency) ?></code>
-						</p>
-
-						<?php if (class_exists('Cron\CronExpression') && $row->isCronExpression()) { ?>
-							<?php if (class_exists('Panlatent\CronExpressionDescriptor\ExpressionDescriptor') && $row->isCronExpression()) { ?>
-								<p class="human-readable-description">
-									<?php
-									// Normalize @minutely to standard cron expression
-								$frequency = $row->frequency === '@minutely' ? '* * * * *' : $row->frequency;
-								$expression = (new \Cron\CronExpression($frequency));
-									$locale = Locale::getDefault();
-									?>
-									<?php echo (new \Panlatent\CronExpressionDescriptor\ExpressionDescriptor($expression, $locale, true))->getDescription();?>
-								</p>
-							<?php } ?>
-						<?php } ?>
-					</td>
-				</tr>
-				<tr>
-					<th><?= __('Enabled') ?></th>
-					<td>
-						<?= $this->element('QueueScheduler.yes_no', ['value' => $row->enabled]) ?> <?= $row->enabled ? __('Yes') : __('No'); ?>
-
-						<?php if (!$row->enabled) { ?>
-							<?php echo $this->Form->postLink($this->element('QueueScheduler.icon', ['name' => 'yes', 'attributes' => ['title' => 'Enable']]) . ' ' . __('Enable'), ['controller' => 'SchedulerRows', 'action' => 'edit', $row->id], ['data' => ['enabled' => 1], 'escapeTitle' => false, 'class' => 'btn btn-small btn-success', 'confirm' => 'Sure to enable?']); ?>
-						<?php } ?>
-					</td>
-				</tr>
-				<tr>
-					<th><?= __('Last Run') ?></th>
-					<td>
-						<?php if ($row->last_run && $row->last_queued_job_id) { ?>
-							<?= $this->Html->link($this->Time->nice($row->last_run), ['plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'view', $row->last_queued_job_id], ['escapeTitle' => false]) ?>
-						<?php } else { ?>
-							<?= $this->Time->nice($row->last_run) ?>
-						<?php } ?>
-					</td>
-				</tr>
-				<?php
-				$nextRun = $row->next_run ?: $row->calculateNextRun();
-				?>
-				<?php if ($nextRun) { ?>
-					<tr>
-						<th><?= __('Next Run') ?></th>
-						<td>
-							<?php if (!$row->enabled) { ?>
-								<div class="canceled"><del><?php echo $this->Time->nice($nextRun); ?></del></div>
-							<?php } else { ?>
-								<div><?php echo $this->Time->nice($nextRun); ?></div>
-							<?php } ?>
-							<div>
-							(<?php echo $this->Time->timeAgoInWords($nextRun); ?>)
-							</div>
-						</td>
-					</tr>
-				<?php } ?>
-				<tr>
-					<th><?= __('Created') ?></th>
-					<td><?= $this->Time->nice($row->created) ?></td>
-				</tr>
-				<tr>
-					<th><?= __('Modified') ?></th>
-					<td><?= $this->Time->nice($row->modified) ?></td>
-				</tr>
-				<tr>
-					<th><?= __('Allow Concurrent') ?></th>
-					<td><?= $this->element('QueueScheduler.yes_no', ['value' => $row->allow_concurrent]) ?> <?= $row->allow_concurrent ? __('Yes') : __('No'); ?></td>
-				</tr>
-			</table>
-			<div class="text">
-				<strong><?= __('Content') ?></strong>
-				<blockquote>
-					<?= $this->Text->autoParagraph(h($row->content)); ?>
-				</blockquote>
-			</div>
-
-			<?php if ($jobStats && $jobStats['total_runs']) { ?>
-			<h3><?= __('Job Statistics') ?></h3>
-			<table class="table table-striped">
-				<tr>
-					<th><?= __('Total Runs') ?></th>
-					<td><?= $jobStats['total_runs'] ?></td>
-				</tr>
-				<tr>
-					<th><?= __('Completed') ?></th>
-					<td><?= $jobStats['completed_runs'] ?: 0 ?></td>
-				</tr>
-				<tr>
-					<th><?= __('Failed') ?></th>
-					<td><?= $jobStats['failed_runs'] ?: 0 ?></td>
-				</tr>
-				<?php if ($jobStats['avg_duration'] !== null) { ?>
-				<tr>
-					<th><?= __('Average Duration') ?></th>
-					<td><?= $this->Number->precision($jobStats['avg_duration'], 1) ?> <?= __('seconds') ?></td>
-				</tr>
-				<tr>
-					<th><?= __('Min / Max Duration') ?></th>
-					<td><?= $jobStats['min_duration'] ?> / <?= $jobStats['max_duration'] ?> <?= __('seconds') ?></td>
-				</tr>
-				<?php } ?>
-			</table>
-			<?php } ?>
-
-			<?php if ($recentJobs) { ?>
-			<h3><?= __('Recent Executions') ?></h3>
-			<table class="table table-striped">
-				<thead>
-					<tr>
-						<th><?= __('Created') ?></th>
-						<th><?= __('Status') ?></th>
-						<th><?= __('Duration') ?></th>
-						<th><?= __('Output') ?></th>
-						<th><?= __('Actions') ?></th>
-					</tr>
-				</thead>
-				<tbody>
-				<?php foreach ($recentJobs as $job) { ?>
-					<tr>
-						<td><?= $this->Html->link($this->Time->nice($job->created), ['plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'view', $job->id], ['escapeTitle' => false]) ?></td>
-						<td>
-							<?php if ($job->completed) { ?>
-								<?php if ($job->failure_message) { ?>
-									<span class="badge badge-danger bg-danger"><?= __('Failed') ?></span>
-								<?php } else { ?>
-									<span class="badge badge-success bg-success"><?= __('Completed') ?></span>
-								<?php } ?>
-							<?php } elseif ($job->fetched) { ?>
-								<span class="badge badge-info bg-info"><?= __('Running') ?></span>
-							<?php } else { ?>
-								<span class="badge badge-secondary bg-secondary"><?= __('Queued') ?></span>
-							<?php } ?>
-						</td>
-						<td>
-							<?php if ($job->fetched && $job->completed) { ?>
-								<?= $job->fetched->diffInSeconds($job->completed) ?> <?= __('seconds') ?>
-							<?php } elseif ($job->fetched) { ?>
-								<?= __('In progress...') ?>
-							<?php } else { ?>
-								-
-							<?php } ?>
-						</td>
-						<td>
-							<?php if ($job->output) { ?>
-								<details>
-									<summary><?= __('Show output') ?> (<?= $this->Number->toReadableSize(strlen($job->output)) ?>)</summary>
-									<pre class="job-output"><?= h($job->output) ?></pre>
-								</details>
-							<?php } elseif ($job->failure_message) { ?>
-								<details>
-									<summary class="text-danger"><?= __('Show error') ?></summary>
-									<pre class="job-output"><?= h($job->failure_message) ?></pre>
-								</details>
-							<?php } else { ?>
-								-
-							<?php } ?>
-						</td>
-						<td>
-							<?= $this->Html->link(__('View Job'), ['plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'view', $job->id]) ?>
-						</td>
-					</tr>
-				<?php } ?>
-				</tbody>
-			</table>
-			<?php } ?>
-
-			<?php if (class_exists('Cron\CronExpression') && $row->isCronExpression()) { ?>
-			<h3>Crontab expression</h3>
-			<p>If you want to port this into a native crontab line, copy and paste the following</p>
-
-			<?php
-				// Normalize @minutely to standard cron expression
-			$frequency = $row->frequency === '@minutely' ? '* * * * *' : $row->frequency;
-			$expression = (new \Cron\CronExpression($frequency));
-			?>
-			<pre class="crontab"><?php echo $expression; ?></pre>
-			<?php } ?>
+<div class="scheduler-rows-view">
+	<div class="d-flex justify-content-between align-items-center mb-4">
+		<h2 class="mb-0">
+			<i class="fas fa-calendar-check me-2"></i><?= h($row->name) ?>
+		</h2>
+		<div>
+			<?= $this->Html->link(
+				'<i class="fas fa-edit me-1"></i>' . __('Edit'),
+				['action' => 'edit', $row->id],
+				['class' => 'btn btn-primary me-2', 'escape' => false],
+			) ?>
+			<?= $this->Form->postLink(
+				'<i class="fas fa-play-circle me-1"></i>' . __('Run Now'),
+				['action' => 'run', $row->id],
+				['class' => 'btn btn-success me-2', 'escape' => false, 'confirm' => __('Are you sure you want to run this now?')],
+			) ?>
+			<?= $this->Form->postLink(
+				'<i class="fas fa-trash me-1"></i>' . __('Delete'),
+				['action' => 'delete', $row->id],
+				['class' => 'btn btn-danger', 'escape' => false, 'confirm' => __('Are you sure you want to delete # {0}?', $row->id)],
+			) ?>
 		</div>
 	</div>
+
+	<div class="row">
+		<div class="col-lg-6 mb-4">
+			<div class="card h-100">
+				<div class="card-header">
+					<i class="fas fa-info-circle me-2"></i><?= __('Schedule Details') ?>
+				</div>
+				<div class="card-body">
+					<table class="table table-striped mb-0">
+						<tr>
+							<th style="width: 40%"><?= __('Type') ?></th>
+							<td><?= $row::types($row->type) ?></td>
+						</tr>
+						<?php if ($row->config) { ?>
+							<tr>
+								<th><?= __('Config') ?></th>
+								<td><pre class="mb-0"><?= json_encode(json_decode($row->param, true), JSON_PRETTY_PRINT) ?></pre></td>
+							</tr>
+						<?php } ?>
+						<tr>
+							<th><?= __('Frequency') ?></th>
+							<td>
+								<code><?= h($row->frequency) ?></code>
+								<?php if (class_exists('Cron\CronExpression') && $row->isCronExpression()) { ?>
+									<?php if (class_exists('Panlatent\CronExpressionDescriptor\ExpressionDescriptor')) { ?>
+										<div class="mt-1 text-muted">
+											<?php
+											$frequency = $row->frequency === '@minutely' ? '* * * * *' : $row->frequency;
+											$expression = new \Cron\CronExpression($frequency);
+											$locale = Locale::getDefault();
+											echo (new \Panlatent\CronExpressionDescriptor\ExpressionDescriptor($expression, $locale, true))->getDescription();
+											?>
+										</div>
+									<?php } ?>
+								<?php } ?>
+							</td>
+						</tr>
+						<tr>
+							<th><?= __('Enabled') ?></th>
+							<td>
+								<?= $this->element('QueueScheduler.yes_no', ['value' => $row->enabled]) ?>
+								<?= $row->enabled ? __('Yes') : __('No') ?>
+								<?php if (!$row->enabled) { ?>
+									<?= $this->Form->postLink(
+										'<i class="fas fa-check me-1"></i>' . __('Enable'),
+										['action' => 'edit', $row->id],
+										[
+											'data' => ['enabled' => 1],
+											'escapeTitle' => false,
+											'class' => 'btn btn-sm btn-success ms-2',
+											'confirm' => __('Sure to enable?'),
+										],
+									) ?>
+								<?php } ?>
+							</td>
+						</tr>
+						<tr>
+							<th><?= __('Allow Concurrent') ?></th>
+							<td>
+								<?= $this->element('QueueScheduler.yes_no', ['value' => $row->allow_concurrent]) ?>
+								<?= $row->allow_concurrent ? __('Yes') : __('No') ?>
+							</td>
+						</tr>
+					</table>
+				</div>
+			</div>
+		</div>
+
+		<div class="col-lg-6 mb-4">
+			<div class="card h-100">
+				<div class="card-header">
+					<i class="fas fa-clock me-2"></i><?= __('Timing Information') ?>
+				</div>
+				<div class="card-body">
+					<table class="table table-striped mb-0">
+						<tr>
+							<th style="width: 40%"><?= __('Last Run') ?></th>
+							<td>
+								<?php if ($row->last_run && $row->last_queued_job_id) { ?>
+									<?= $this->Html->link(
+										$this->Time->nice($row->last_run),
+										['plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'view', $row->last_queued_job_id],
+										['escapeTitle' => false],
+									) ?>
+								<?php } elseif ($row->last_run) { ?>
+									<?= $this->Time->nice($row->last_run) ?>
+								<?php } else { ?>
+									<span class="text-muted"><?= __('Never') ?></span>
+								<?php } ?>
+							</td>
+						</tr>
+						<?php
+						$nextRun = $row->next_run ?: $row->calculateNextRun();
+						?>
+						<?php if ($nextRun) { ?>
+							<tr>
+								<th><?= __('Next Run') ?></th>
+								<td>
+									<?php if (!$row->enabled) { ?>
+										<del class="text-muted"><?= $this->Time->nice($nextRun) ?></del>
+									<?php } else { ?>
+										<?= $this->Time->nice($nextRun) ?>
+									<?php } ?>
+									<div class="small text-muted"><?= $this->Time->timeAgoInWords($nextRun) ?></div>
+								</td>
+							</tr>
+						<?php } ?>
+						<tr>
+							<th><?= __('Created') ?></th>
+							<td><?= $this->Time->nice($row->created) ?></td>
+						</tr>
+						<tr>
+							<th><?= __('Modified') ?></th>
+							<td><?= $this->Time->nice($row->modified) ?></td>
+						</tr>
+					</table>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div class="card mb-4">
+		<div class="card-header">
+			<i class="fas fa-code me-2"></i><?= __('Content') ?>
+		</div>
+		<div class="card-body">
+			<pre class="mb-0"><?= h($row->content) ?></pre>
+		</div>
+	</div>
+
+	<?php if ($jobStats && $jobStats['total_runs']) { ?>
+		<div class="card mb-4">
+			<div class="card-header">
+				<i class="fas fa-chart-bar me-2"></i><?= __('Job Statistics') ?>
+			</div>
+			<div class="card-body">
+				<div class="row">
+					<div class="col-md-3 mb-3 mb-md-0">
+						<div class="text-center">
+							<div class="h3 mb-0"><?= $jobStats['total_runs'] ?></div>
+							<small class="text-muted"><?= __('Total Runs') ?></small>
+						</div>
+					</div>
+					<div class="col-md-3 mb-3 mb-md-0">
+						<div class="text-center">
+							<div class="h3 mb-0 text-success"><?= $jobStats['completed_runs'] ?: 0 ?></div>
+							<small class="text-muted"><?= __('Completed') ?></small>
+						</div>
+					</div>
+					<div class="col-md-3 mb-3 mb-md-0">
+						<div class="text-center">
+							<div class="h3 mb-0 text-danger"><?= $jobStats['failed_runs'] ?: 0 ?></div>
+							<small class="text-muted"><?= __('Failed') ?></small>
+						</div>
+					</div>
+					<?php if ($jobStats['avg_duration'] !== null) { ?>
+						<div class="col-md-3">
+							<div class="text-center">
+								<div class="h3 mb-0"><?= $this->Number->precision($jobStats['avg_duration'], 1) ?>s</div>
+								<small class="text-muted"><?= __('Avg Duration') ?></small>
+								<div class="small text-muted"><?= $jobStats['min_duration'] ?>s - <?= $jobStats['max_duration'] ?>s</div>
+							</div>
+						</div>
+					<?php } ?>
+				</div>
+			</div>
+		</div>
+	<?php } ?>
+
+	<?php if ($recentJobs) { ?>
+		<div class="card mb-4">
+			<div class="card-header d-flex justify-content-between align-items-center">
+				<span><i class="fas fa-history me-2"></i><?= __('Recent Executions') ?></span>
+				<?= $this->Html->link(
+					__('View All in Queue'),
+					['plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'index', '?' => ['search' => $row->job_reference]],
+					['class' => 'btn btn-sm btn-outline-secondary'],
+				) ?>
+			</div>
+			<div class="card-body p-0">
+				<div class="table-responsive">
+					<table class="table table-hover mb-0">
+						<thead>
+							<tr>
+								<th><?= __('Created') ?></th>
+								<th><?= __('Status') ?></th>
+								<th><?= __('Duration') ?></th>
+								<th><?= __('Output') ?></th>
+								<th class="text-end"><?= __('Actions') ?></th>
+							</tr>
+						</thead>
+						<tbody>
+							<?php foreach ($recentJobs as $job) { ?>
+								<tr>
+									<td>
+										<?= $this->Html->link(
+											$this->Time->nice($job->created),
+											['plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'view', $job->id],
+											['escapeTitle' => false],
+										) ?>
+									</td>
+									<td>
+										<?php if ($job->completed) { ?>
+											<?php if ($job->failure_message) { ?>
+												<span class="badge bg-danger"><?= __('Failed') ?></span>
+											<?php } else { ?>
+												<span class="badge bg-success"><?= __('Completed') ?></span>
+											<?php } ?>
+										<?php } elseif ($job->fetched) { ?>
+											<span class="badge bg-info"><?= __('Running') ?></span>
+										<?php } else { ?>
+											<span class="badge bg-secondary"><?= __('Queued') ?></span>
+										<?php } ?>
+									</td>
+									<td>
+										<?php if ($job->fetched && $job->completed) { ?>
+											<?= $job->fetched->diffInSeconds($job->completed) ?>s
+										<?php } elseif ($job->fetched) { ?>
+											<span class="text-muted"><?= __('In progress...') ?></span>
+										<?php } else { ?>
+											-
+										<?php } ?>
+									</td>
+									<td>
+										<?php if ($job->output) { ?>
+											<details>
+												<summary class="btn btn-sm btn-outline-secondary">
+													<?= __('Show output') ?> (<?= $this->Number->toReadableSize(strlen($job->output)) ?>)
+												</summary>
+												<pre class="mt-2 p-2 bg-light small"><?= h($job->output) ?></pre>
+											</details>
+										<?php } elseif ($job->failure_message) { ?>
+											<details>
+												<summary class="btn btn-sm btn-outline-danger">
+													<?= __('Show error') ?>
+												</summary>
+												<pre class="mt-2 p-2 bg-light small text-danger"><?= h($job->failure_message) ?></pre>
+											</details>
+										<?php } else { ?>
+											-
+										<?php } ?>
+									</td>
+									<td class="text-end">
+										<?= $this->Html->link(
+											'<i class="fas fa-eye"></i>',
+											['plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'view', $job->id],
+											['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-secondary', 'title' => __('View Job')],
+										) ?>
+									</td>
+								</tr>
+							<?php } ?>
+						</tbody>
+					</table>
+				</div>
+			</div>
+		</div>
+	<?php } ?>
+
+	<?php if (class_exists('Cron\CronExpression') && $row->isCronExpression()) { ?>
+		<div class="card">
+			<div class="card-header">
+				<i class="fas fa-terminal me-2"></i><?= __('Crontab Expression') ?>
+			</div>
+			<div class="card-body">
+				<p class="text-muted"><?= __('If you want to port this into a native crontab line, copy and paste the following:') ?></p>
+				<?php
+				$frequency = $row->frequency === '@minutely' ? '* * * * *' : $row->frequency;
+				$expression = new \Cron\CronExpression($frequency);
+				?>
+				<pre class="mb-0"><?= $expression ?></pre>
+			</div>
+		</div>
+	<?php } ?>
 </div>

--- a/templates/element/QueueScheduler/mobile_nav.php
+++ b/templates/element/QueueScheduler/mobile_nav.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Mobile navigation element for QueueScheduler admin.
+ *
+ * @var \Cake\View\View $this
+ */
+
+$request = $this->getRequest();
+$controller = $request ? $request->getParam('controller') : '';
+$action = $request ? $request->getParam('action') : '';
+?>
+<nav class="nav flex-column py-3">
+	<div class="px-3 mb-2">
+		<small class="text-white-50 text-uppercase fw-semibold"><?= __('Dashboard') ?></small>
+	</div>
+	<a class="nav-link text-white<?= $controller === 'QueueScheduler' && $action === 'index' ? ' bg-primary rounded-0' : '' ?>" href="<?= $this->Url->build(['plugin' => 'QueueScheduler', 'prefix' => 'Admin', 'controller' => 'QueueScheduler', 'action' => 'index']) ?>">
+		<i class="fas fa-tachometer-alt me-2"></i><?= __('Overview') ?>
+	</a>
+
+	<div class="px-3 mt-3 mb-2">
+		<small class="text-white-50 text-uppercase fw-semibold"><?= __('Scheduled Jobs') ?></small>
+	</div>
+	<a class="nav-link text-white<?= $controller === 'SchedulerRows' && $action === 'index' ? ' bg-primary rounded-0' : '' ?>" href="<?= $this->Url->build(['plugin' => 'QueueScheduler', 'prefix' => 'Admin', 'controller' => 'SchedulerRows', 'action' => 'index']) ?>">
+		<i class="fas fa-list me-2"></i><?= __('All Schedules') ?>
+	</a>
+	<a class="nav-link text-white<?= $controller === 'SchedulerRows' && $action === 'add' ? ' bg-primary rounded-0' : '' ?>" href="<?= $this->Url->build(['plugin' => 'QueueScheduler', 'prefix' => 'Admin', 'controller' => 'SchedulerRows', 'action' => 'add']) ?>">
+		<i class="fas fa-plus me-2"></i><?= __('Add Schedule') ?>
+	</a>
+
+	<div class="px-3 mt-3 mb-2">
+		<small class="text-white-50 text-uppercase fw-semibold"><?= __('Reference') ?></small>
+	</div>
+	<a class="nav-link text-white<?= $controller === 'QueueScheduler' && $action === 'intervals' ? ' bg-primary rounded-0' : '' ?>" href="<?= $this->Url->build(['plugin' => 'QueueScheduler', 'prefix' => 'Admin', 'controller' => 'QueueScheduler', 'action' => 'intervals']) ?>">
+		<i class="fas fa-clock me-2"></i><?= __('Intervals Help') ?>
+	</a>
+
+	<?php if (\Cake\Core\Plugin::isLoaded('Queue')): ?>
+	<div class="px-3 mt-3 mb-2">
+		<small class="text-white-50 text-uppercase fw-semibold"><?= __('Queue Plugin') ?></small>
+	</div>
+	<a class="nav-link text-white" href="<?= $this->Url->build(['plugin' => 'Queue', 'prefix' => 'Admin', 'controller' => 'Queue', 'action' => 'index']) ?>">
+		<i class="fas fa-layer-group me-2"></i><?= __('Queue Dashboard') ?>
+	</a>
+	<a class="nav-link text-white" href="<?= $this->Url->build(['plugin' => 'Queue', 'prefix' => 'Admin', 'controller' => 'QueuedJobs', 'action' => 'index']) ?>">
+		<i class="fas fa-tasks me-2"></i><?= __('Queued Jobs') ?>
+	</a>
+	<?php endif; ?>
+</nav>

--- a/templates/element/QueueScheduler/sidebar.php
+++ b/templates/element/QueueScheduler/sidebar.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Sidebar navigation element for QueueScheduler admin.
+ *
+ * @var \Cake\View\View $this
+ */
+
+$request = $this->getRequest();
+$controller = $request ? $request->getParam('controller') : '';
+$action = $request ? $request->getParam('action') : '';
+?>
+<aside class="scheduler-sidebar d-none d-lg-block">
+	<div class="nav-section">
+		<div class="nav-section-title"><?= __('Dashboard') ?></div>
+		<nav class="nav flex-column">
+			<a class="nav-link<?= $controller === 'QueueScheduler' && $action === 'index' ? ' active' : '' ?>" href="<?= $this->Url->build(['plugin' => 'QueueScheduler', 'prefix' => 'Admin', 'controller' => 'QueueScheduler', 'action' => 'index']) ?>">
+				<i class="fas fa-tachometer-alt"></i><?= __('Overview') ?>
+			</a>
+		</nav>
+	</div>
+
+	<div class="nav-section">
+		<div class="nav-section-title"><?= __('Scheduled Jobs') ?></div>
+		<nav class="nav flex-column">
+			<a class="nav-link<?= $controller === 'SchedulerRows' && $action === 'index' ? ' active' : '' ?>" href="<?= $this->Url->build(['plugin' => 'QueueScheduler', 'prefix' => 'Admin', 'controller' => 'SchedulerRows', 'action' => 'index']) ?>">
+				<i class="fas fa-list"></i><?= __('All Schedules') ?>
+			</a>
+			<a class="nav-link<?= $controller === 'SchedulerRows' && $action === 'add' ? ' active' : '' ?>" href="<?= $this->Url->build(['plugin' => 'QueueScheduler', 'prefix' => 'Admin', 'controller' => 'SchedulerRows', 'action' => 'add']) ?>">
+				<i class="fas fa-plus"></i><?= __('Add Schedule') ?>
+			</a>
+		</nav>
+	</div>
+
+	<div class="nav-section">
+		<div class="nav-section-title"><?= __('Reference') ?></div>
+		<nav class="nav flex-column">
+			<a class="nav-link<?= $controller === 'QueueScheduler' && $action === 'intervals' ? ' active' : '' ?>" href="<?= $this->Url->build(['plugin' => 'QueueScheduler', 'prefix' => 'Admin', 'controller' => 'QueueScheduler', 'action' => 'intervals']) ?>">
+				<i class="fas fa-clock"></i><?= __('Intervals Help') ?>
+			</a>
+		</nav>
+	</div>
+
+	<?php if (\Cake\Core\Plugin::isLoaded('Queue')): ?>
+	<div class="nav-section">
+		<div class="nav-section-title"><?= __('Queue Plugin') ?></div>
+		<nav class="nav flex-column">
+			<a class="nav-link" href="<?= $this->Url->build(['plugin' => 'Queue', 'prefix' => 'Admin', 'controller' => 'Queue', 'action' => 'index']) ?>">
+				<i class="fas fa-layer-group"></i><?= __('Queue Dashboard') ?>
+			</a>
+			<a class="nav-link" href="<?= $this->Url->build(['plugin' => 'Queue', 'prefix' => 'Admin', 'controller' => 'QueuedJobs', 'action' => 'index']) ?>">
+				<i class="fas fa-tasks"></i><?= __('Queued Jobs') ?>
+			</a>
+		</nav>
+	</div>
+	<?php endif; ?>
+</aside>

--- a/templates/element/available.php
+++ b/templates/element/available.php
@@ -9,32 +9,25 @@
 $scheduler = $this->Scheduler;
 ?>
 <div class="row">
-	<div class="col-md-6">
-		<h3>Available Commands</h3>
-		<ul>
-			<?php foreach ($scheduler->availableCommands() as $name => $commmand) {  ?>
-				<li>
-					<p>
-						<?php echo h($name); ?>
-						<br>
-						<small><code><?php echo h($commmand); ?></code></small>
-					</p>
+	<div class="col-md-6 mb-3 mb-md-0">
+		<h5><i class="fas fa-terminal me-2"></i><?= __('Available Commands') ?></h5>
+		<ul class="list-unstyled">
+			<?php foreach ($scheduler->availableCommands() as $name => $command) { ?>
+				<li class="mb-2">
+					<strong><?= h($name) ?></strong><br>
+					<code class="small"><?= h($command) ?></code>
 				</li>
 			<?php } ?>
 		</ul>
-
 	</div>
 
 	<div class="col-md-6">
-		<h3>Available Queue Tasks</h3>
-		<ul>
-			<?php foreach ($scheduler->availableQueueTasks() as $name => $queueTask) {  ?>
-				<li>
-					<p>
-						<?php echo h($name); ?>
-						<br>
-						<small><code><?php echo h($queueTask); ?></code></small>
-					</p>
+		<h5><i class="fas fa-tasks me-2"></i><?= __('Available Queue Tasks') ?></h5>
+		<ul class="list-unstyled">
+			<?php foreach ($scheduler->availableQueueTasks() as $name => $queueTask) { ?>
+				<li class="mb-2">
+					<strong><?= h($name) ?></strong><br>
+					<code class="small"><?= h($queueTask) ?></code>
 				</li>
 			<?php } ?>
 		</ul>

--- a/templates/element/flash/error.php
+++ b/templates/element/flash/error.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Bootstrap 5 error flash message element.
+ *
+ * @var \Cake\View\View $this
+ * @var array<string, mixed> $params
+ * @var string $message
+ */
+$class = 'alert alert-danger alert-dismissible fade show';
+if (!empty($params['class'])) {
+	$class .= ' ' . $params['class'];
+}
+if (!isset($params['escape']) || $params['escape'] !== false) {
+	$message = h($message);
+}
+?>
+<div class="<?= $class ?>" role="alert">
+	<i class="fas fa-exclamation-circle me-2"></i>
+	<?= $message ?>
+	<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+</div>

--- a/templates/element/flash/info.php
+++ b/templates/element/flash/info.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Bootstrap 5 info flash message element.
+ *
+ * @var \Cake\View\View $this
+ * @var array<string, mixed> $params
+ * @var string $message
+ */
+$class = 'alert alert-info alert-dismissible fade show';
+if (!empty($params['class'])) {
+	$class .= ' ' . $params['class'];
+}
+if (!isset($params['escape']) || $params['escape'] !== false) {
+	$message = h($message);
+}
+?>
+<div class="<?= $class ?>" role="alert">
+	<i class="fas fa-info-circle me-2"></i>
+	<?= $message ?>
+	<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+</div>

--- a/templates/element/flash/success.php
+++ b/templates/element/flash/success.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Bootstrap 5 success flash message element.
+ *
+ * @var \Cake\View\View $this
+ * @var array<string, mixed> $params
+ * @var string $message
+ */
+$class = 'alert alert-success alert-dismissible fade show';
+if (!empty($params['class'])) {
+	$class .= ' ' . $params['class'];
+}
+if (!isset($params['escape']) || $params['escape'] !== false) {
+	$message = h($message);
+}
+?>
+<div class="<?= $class ?>" role="alert">
+	<i class="fas fa-check-circle me-2"></i>
+	<?= $message ?>
+	<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+</div>

--- a/templates/element/flash/warning.php
+++ b/templates/element/flash/warning.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Bootstrap 5 warning flash message element.
+ *
+ * @var \Cake\View\View $this
+ * @var array<string, mixed> $params
+ * @var string $message
+ */
+$class = 'alert alert-warning alert-dismissible fade show';
+if (!empty($params['class'])) {
+	$class .= ' ' . $params['class'];
+}
+if (!isset($params['escape']) || $params['escape'] !== false) {
+	$message = h($message);
+}
+?>
+<div class="<?= $class ?>" role="alert">
+	<i class="fas fa-exclamation-triangle me-2"></i>
+	<?= $message ?>
+	<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+</div>

--- a/templates/element/icon.php
+++ b/templates/element/icon.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Icon element with text fallback when Icon helper is not available.
+ * Icon element with Font Awesome fallback when Icon helper is not available.
  *
  * @var \App\View\AppView $this
  * @var string $name Icon name
@@ -11,7 +11,17 @@
 $options ??= [];
 $attributes ??= [];
 
-$fallbackMap = [
+$fontAwesomeMap = [
+	'view' => 'fas fa-eye',
+	'edit' => 'fas fa-edit',
+	'delete' => 'fas fa-trash',
+	'play-circle' => 'fas fa-play-circle',
+	'stop-circle' => 'fas fa-stop-circle',
+	'yes' => 'fas fa-check',
+	'no' => 'fas fa-times',
+];
+
+$fallbackTextMap = [
 	'view' => 'View',
 	'edit' => 'Edit',
 	'delete' => 'Del',
@@ -23,7 +33,14 @@ $fallbackMap = [
 
 if ($this->helpers()->has('Icon')) {
 	echo $this->Icon->render($name, $options, $attributes);
+} elseif (isset($fontAwesomeMap[$name])) {
+	$title = $attributes['title'] ?? $fallbackTextMap[$name] ?? ucfirst($name);
+	$class = $fontAwesomeMap[$name];
+	if (!empty($attributes['class'])) {
+		$class .= ' ' . $attributes['class'];
+	}
+	echo '<i class="' . h($class) . '" title="' . h($title) . '"></i>';
 } else {
-	$title = $attributes['title'] ?? $fallbackMap[$name] ?? ucfirst($name);
-	echo '<span title="' . h($title) . '">[' . h($fallbackMap[$name] ?? ucfirst($name)) . ']</span>';
+	$title = $attributes['title'] ?? $fallbackTextMap[$name] ?? ucfirst($name);
+	echo '<span title="' . h($title) . '">[' . h($fallbackTextMap[$name] ?? ucfirst($name)) . ']</span>';
 }

--- a/templates/element/quick_add.php
+++ b/templates/element/quick_add.php
@@ -12,19 +12,19 @@ $scheduler = $this->Scheduler;
 ?>
 <div class="card mb-4">
 	<div class="card-header">
-		<a class="text-decoration-none" data-toggle="collapse" data-bs-toggle="collapse" href="#quick-add-body" role="button" aria-expanded="false" aria-controls="quick-add-body">
-			<h3 class="mb-0"><?= __('Quick Add') ?> <small>&#9660;</small></h3>
+		<a class="text-decoration-none" data-bs-toggle="collapse" href="#quick-add-body" role="button" aria-expanded="false" aria-controls="quick-add-body">
+			<i class="fas fa-bolt me-2"></i><?= __('Quick Add') ?> <small>&#9660;</small>
 		</a>
 	</div>
 	<div class="collapse" id="quick-add-body">
 		<div class="card-body">
 			<div class="row">
-				<div class="col-md-6">
-					<h4><?= __('Cake Commands') ?></h4>
+				<div class="col-md-6 mb-3 mb-md-0">
+					<h5><i class="fas fa-terminal me-2"></i><?= __('Cake Commands') ?></h5>
 					<div class="list-group">
 						<?php foreach ($scheduler->availableCommands() as $name => $command) { ?>
 							<?= $this->Html->link(
-								h($name) . '<br><small class="text-muted"><code>' . h($command) . '</code></small>',
+								'<strong>' . h($name) . '</strong><br><small class="text-muted"><code>' . h($command) . '</code></small>',
 								['action' => 'add', '?' => [
 									'type' => SchedulerRow::TYPE_CAKE_COMMAND,
 									'content' => $command,
@@ -37,11 +37,11 @@ $scheduler = $this->Scheduler;
 				</div>
 
 				<div class="col-md-6">
-					<h4><?= __('Queue Tasks') ?></h4>
+					<h5><i class="fas fa-tasks me-2"></i><?= __('Queue Tasks') ?></h5>
 					<div class="list-group">
 						<?php foreach ($scheduler->availableQueueTasks() as $name => $queueTask) { ?>
 							<?= $this->Html->link(
-								h($name) . '<br><small class="text-muted"><code>' . h($queueTask) . '</code></small>',
+								'<strong>' . h($name) . '</strong><br><small class="text-muted"><code>' . h($queueTask) . '</code></small>',
 								['action' => 'add', '?' => [
 									'type' => SchedulerRow::TYPE_QUEUE_TASK,
 									'content' => $queueTask,

--- a/templates/element/quick_add.php
+++ b/templates/element/quick_add.php
@@ -1,5 +1,7 @@
 <?php
 /**
+ * Quick Add element with autocomplete search.
+ *
  * @var \App\View\AppView $this
  */
 
@@ -9,50 +11,69 @@ use QueueScheduler\Model\Entity\SchedulerRow;
  * @var \QueueScheduler\View\Helper\SchedulerHelper $scheduler
  */
 $scheduler = $this->Scheduler;
+
+$commands = $scheduler->availableCommands();
+$tasks = $scheduler->availableQueueTasks();
 ?>
 <div class="card mb-4">
-	<div class="card-header">
-		<a class="text-decoration-none" data-bs-toggle="collapse" href="#quick-add-body" role="button" aria-expanded="false" aria-controls="quick-add-body">
-			<i class="fas fa-bolt me-2"></i><?= __('Quick Add') ?> <small>&#9660;</small>
-		</a>
-	</div>
-	<div class="collapse" id="quick-add-body">
-		<div class="card-body">
-			<div class="row">
-				<div class="col-md-6 mb-3 mb-md-0">
-					<h5><i class="fas fa-terminal me-2"></i><?= __('Cake Commands') ?></h5>
-					<div class="list-group">
-						<?php foreach ($scheduler->availableCommands() as $name => $command) { ?>
-							<?= $this->Html->link(
-								'<strong>' . h($name) . '</strong><br><small class="text-muted"><code>' . h($command) . '</code></small>',
-								['action' => 'add', '?' => [
-									'type' => SchedulerRow::TYPE_CAKE_COMMAND,
-									'content' => $command,
-									'name' => $name,
-								]],
-								['class' => 'list-group-item list-group-item-action', 'escape' => false],
-							) ?>
-						<?php } ?>
-					</div>
-				</div>
-
-				<div class="col-md-6">
-					<h5><i class="fas fa-tasks me-2"></i><?= __('Queue Tasks') ?></h5>
-					<div class="list-group">
-						<?php foreach ($scheduler->availableQueueTasks() as $name => $queueTask) { ?>
-							<?= $this->Html->link(
-								'<strong>' . h($name) . '</strong><br><small class="text-muted"><code>' . h($queueTask) . '</code></small>',
-								['action' => 'add', '?' => [
-									'type' => SchedulerRow::TYPE_QUEUE_TASK,
-									'content' => $queueTask,
-									'name' => $name,
-								]],
-								['class' => 'list-group-item list-group-item-action', 'escape' => false],
-							) ?>
-						<?php } ?>
-					</div>
-				</div>
-			</div>
-		</div>
+	<div class="card-body">
+		<label class="form-label" for="quick-add-search">
+			<i class="fas fa-bolt me-2"></i><?= __('Quick Add') ?>
+		</label>
+		<input type="text" id="quick-add-search" class="form-control form-control-lg"
+			   list="quick-add-options" placeholder="<?= __('Search commands or tasks...') ?>"
+			   autocomplete="off">
+		<datalist id="quick-add-options">
+			<?php foreach ($commands as $name => $command) { ?>
+				<option value="<?= h($name) ?>" data-type="<?= SchedulerRow::TYPE_CAKE_COMMAND ?>" data-content="<?= h($command) ?>">
+			<?php } ?>
+			<?php foreach ($tasks as $name => $task) { ?>
+				<option value="<?= h($name) ?>" data-type="<?= SchedulerRow::TYPE_QUEUE_TASK ?>" data-content="<?= h($task) ?>">
+			<?php } ?>
+		</datalist>
+		<div class="form-text"><?= __('Select a command or task to pre-fill the form') ?></div>
 	</div>
 </div>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+	var searchInput = document.getElementById('quick-add-search');
+	if (!searchInput) return;
+
+	// Build lookup map from datalist options
+	var optionsMap = {};
+	document.querySelectorAll('#quick-add-options option').forEach(function(opt) {
+		optionsMap[opt.value] = {
+			type: opt.dataset.type,
+			content: opt.dataset.content
+		};
+	});
+
+	searchInput.addEventListener('change', function() {
+		var selected = optionsMap[this.value];
+		if (selected) {
+			var params = new URLSearchParams({
+				type: selected.type,
+				content: selected.content,
+				name: this.value
+			});
+			window.location.href = window.location.pathname + '?' + params.toString();
+		}
+	});
+
+	// Also handle Enter key for better UX
+	searchInput.addEventListener('keydown', function(e) {
+		if (e.key === 'Enter') {
+			var selected = optionsMap[this.value];
+			if (selected) {
+				e.preventDefault();
+				var params = new URLSearchParams({
+					type: selected.type,
+					content: selected.content,
+					name: this.value
+				});
+				window.location.href = window.location.pathname + '?' + params.toString();
+			}
+		}
+	});
+});
+</script>

--- a/templates/element/quick_add.php
+++ b/templates/element/quick_add.php
@@ -25,10 +25,10 @@ $tasks = $scheduler->availableQueueTasks();
 			   autocomplete="off">
 		<datalist id="quick-add-options">
 			<?php foreach ($commands as $name => $command) { ?>
-				<option value="<?= h($name) ?>" data-type="<?= SchedulerRow::TYPE_CAKE_COMMAND ?>" data-content="<?= h($command) ?>">
+				<option value="<?= h($name) ?> (Command)" data-name="<?= h($name) ?>" data-type="<?= SchedulerRow::TYPE_CAKE_COMMAND ?>" data-content="<?= h($command) ?>">
 			<?php } ?>
 			<?php foreach ($tasks as $name => $task) { ?>
-				<option value="<?= h($name) ?>" data-type="<?= SchedulerRow::TYPE_QUEUE_TASK ?>" data-content="<?= h($task) ?>">
+				<option value="<?= h($name) ?> (Task)" data-name="<?= h($name) ?>" data-type="<?= SchedulerRow::TYPE_QUEUE_TASK ?>" data-content="<?= h($task) ?>">
 			<?php } ?>
 		</datalist>
 		<div class="form-text"><?= __('Select a command or task to pre-fill the form') ?></div>
@@ -43,22 +43,25 @@ document.addEventListener('DOMContentLoaded', function() {
 	var optionsMap = {};
 	document.querySelectorAll('#quick-add-options option').forEach(function(opt) {
 		optionsMap[opt.value] = {
+			name: opt.dataset.name,
 			type: opt.dataset.type,
 			content: opt.dataset.content
 		};
 	});
 
-	searchInput.addEventListener('change', function() {
-		var selected = optionsMap[this.value];
+	function handleSelection() {
+		var selected = optionsMap[searchInput.value];
 		if (selected) {
 			var params = new URLSearchParams({
 				type: selected.type,
 				content: selected.content,
-				name: this.value
+				name: selected.name
 			});
 			window.location.href = window.location.pathname + '?' + params.toString();
 		}
-	});
+	}
+
+	searchInput.addEventListener('change', handleSelection);
 
 	// Also handle Enter key for better UX
 	searchInput.addEventListener('keydown', function(e) {
@@ -66,12 +69,7 @@ document.addEventListener('DOMContentLoaded', function() {
 			var selected = optionsMap[this.value];
 			if (selected) {
 				e.preventDefault();
-				var params = new URLSearchParams({
-					type: selected.type,
-					content: selected.content,
-					name: this.value
-				});
-				window.location.href = window.location.pathname + '?' + params.toString();
+				handleSelection();
 			}
 		}
 	});

--- a/templates/element/yes_no.php
+++ b/templates/element/yes_no.php
@@ -1,19 +1,23 @@
 <?php
 /**
- * Overwrite this element snippet locally to customize if needed.
+ * Yes/No element with Bootstrap styling fallback.
  *
  * @var \App\View\AppView $this
  * @var bool $value
  */
 ?>
 <?php
-	if ($this->helpers()->has('Templating')) {
-		echo $this->Templating->yesNo($value);
-	} elseif ($this->helpers()->has('IconSnippet')) {
-		echo $this->IconSnippet->yesNo($value);
-	} elseif ($this->helpers()->has('Format')) {
-		echo $this->Format->yesNo($value);
+if ($this->helpers()->has('Templating')) {
+	echo $this->Templating->yesNo($value);
+} elseif ($this->helpers()->has('IconSnippet')) {
+	echo $this->IconSnippet->yesNo($value);
+} elseif ($this->helpers()->has('Format')) {
+	echo $this->Format->yesNo($value);
+} else {
+	if ($value) {
+		echo '<span class="yes-no yes-no-yes"><i class="fas fa-check"></i></span>';
 	} else {
-		echo $value ? '<span class="yes-no yes-no-yes">Yes</span>' : '<span class="yes-no yes-no-no">No</span>';
+		echo '<span class="yes-no yes-no-no"><i class="fas fa-times"></i></span>';
 	}
+}
 ?>

--- a/templates/layout/queue_scheduler.php
+++ b/templates/layout/queue_scheduler.php
@@ -1,0 +1,432 @@
+<?php
+/**
+ * QueueScheduler Admin Layout
+ *
+ * Self-contained admin layout using Bootstrap 5 and Font Awesome 6 via CDN.
+ * Completely isolated from host application's CSS/JS.
+ *
+ * @var \Cake\View\View $this
+ */
+
+use Cake\Core\Configure;
+
+$autoRefresh = 0;
+$request = $this->getRequest();
+if ($request && $request->getParam('controller') === 'QueueScheduler' && $request->getParam('action') === 'index') {
+	$autoRefresh = (int)Configure::read('QueueScheduler.dashboardAutoRefresh') ?: 0;
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title><?= $this->fetch('title') ? strip_tags($this->fetch('title')) . ' - ' : '' ?>Queue Scheduler Admin</title>
+
+	<!-- Bootstrap 5.3.3 CSS -->
+	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+
+	<!-- Font Awesome 6.7.2 -->
+	<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" rel="stylesheet" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous">
+
+	<style>
+		:root {
+			--scheduler-primary: #6f42c1;
+			--scheduler-success: #198754;
+			--scheduler-warning: #ffc107;
+			--scheduler-danger: #dc3545;
+			--scheduler-info: #0dcaf0;
+			--scheduler-secondary: #6c757d;
+			--scheduler-dark: #212529;
+			--scheduler-light: #f8f9fa;
+			--scheduler-sidebar-bg: linear-gradient(135deg, #4a2c6a 0%, #2d1a42 100%);
+			--scheduler-sidebar-width: 260px;
+		}
+
+		body {
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+			background-color: #f4f6f9;
+			min-height: 100vh;
+		}
+
+		/* Navbar */
+		.scheduler-navbar {
+			background: var(--scheduler-dark);
+			box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+		}
+
+		.scheduler-navbar .navbar-brand {
+			font-weight: 600;
+			color: #fff;
+		}
+
+		.scheduler-navbar .navbar-brand i {
+			color: var(--scheduler-primary);
+		}
+
+		/* Sidebar */
+		.scheduler-sidebar {
+			background: var(--scheduler-sidebar-bg);
+			min-height: calc(100vh - 56px);
+			width: var(--scheduler-sidebar-width);
+			position: fixed;
+			left: 0;
+			top: 56px;
+			padding: 1.5rem 0;
+			overflow-y: auto;
+		}
+
+		.scheduler-sidebar .nav-section {
+			padding: 0 1rem;
+			margin-bottom: 1.5rem;
+		}
+
+		.scheduler-sidebar .nav-section-title {
+			color: rgba(255,255,255,0.5);
+			font-size: 0.75rem;
+			text-transform: uppercase;
+			letter-spacing: 0.05em;
+			padding: 0 0.75rem;
+			margin-bottom: 0.5rem;
+		}
+
+		.scheduler-sidebar .nav-link {
+			color: rgba(255,255,255,0.8);
+			padding: 0.6rem 0.75rem;
+			border-radius: 0.375rem;
+			margin-bottom: 0.25rem;
+			transition: all 0.2s ease;
+		}
+
+		.scheduler-sidebar .nav-link:hover {
+			color: #fff;
+			background: rgba(255,255,255,0.1);
+		}
+
+		.scheduler-sidebar .nav-link.active {
+			color: #fff;
+			background: var(--scheduler-primary);
+		}
+
+		.scheduler-sidebar .nav-link i {
+			width: 1.25rem;
+			margin-right: 0.5rem;
+		}
+
+		/* Main Content */
+		.scheduler-main {
+			margin-left: var(--scheduler-sidebar-width);
+			padding: 1.5rem;
+			min-height: calc(100vh - 56px);
+		}
+
+		/* Stats Cards */
+		.stats-card {
+			border: none;
+			border-radius: 0.5rem;
+			box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+			transition: transform 0.2s ease, box-shadow 0.2s ease;
+			overflow: hidden;
+		}
+
+		.stats-card:hover {
+			transform: translateY(-2px);
+			box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+		}
+
+		.stats-card .card-body {
+			padding: 1.25rem;
+		}
+
+		.stats-card .stats-icon {
+			width: 48px;
+			height: 48px;
+			border-radius: 0.5rem;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			font-size: 1.25rem;
+		}
+
+		.stats-card .stats-value {
+			font-size: 1.75rem;
+			font-weight: 700;
+			line-height: 1.2;
+		}
+
+		.stats-card .stats-label {
+			color: var(--scheduler-secondary);
+			font-size: 0.875rem;
+		}
+
+		/* Status Badges */
+		.badge-enabled {
+			background-color: var(--scheduler-success);
+		}
+
+		.badge-disabled {
+			background-color: var(--scheduler-secondary);
+		}
+
+		.badge-running {
+			background-color: var(--scheduler-primary);
+		}
+
+		.badge-queued {
+			background-color: var(--scheduler-warning);
+			color: #000;
+		}
+
+		.badge-failed {
+			background-color: var(--scheduler-danger);
+		}
+
+		/* Tables */
+		.scheduler-table {
+			background: #fff;
+			border-radius: 0.5rem;
+			overflow: hidden;
+			box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+		}
+
+		.scheduler-table thead th {
+			background: var(--scheduler-light);
+			border-bottom: 2px solid #dee2e6;
+			font-weight: 600;
+			font-size: 0.875rem;
+			text-transform: uppercase;
+			letter-spacing: 0.025em;
+			color: var(--scheduler-secondary);
+		}
+
+		.scheduler-table tbody tr:hover {
+			background-color: rgba(111, 66, 193, 0.04);
+		}
+
+		/* Action Buttons */
+		.btn-action {
+			padding: 0.25rem 0.5rem;
+			font-size: 0.875rem;
+		}
+
+		/* Flash Messages */
+		.scheduler-flash {
+			margin-bottom: 1rem;
+		}
+
+		/* Footer */
+		.scheduler-footer {
+			margin-left: var(--scheduler-sidebar-width);
+			padding: 1rem 1.5rem;
+			background: #fff;
+			border-top: 1px solid #dee2e6;
+			color: var(--scheduler-secondary);
+			font-size: 0.875rem;
+		}
+
+		/* Responsive */
+		@media (max-width: 991.98px) {
+			.scheduler-sidebar {
+				position: relative;
+				width: 100%;
+				min-height: auto;
+				top: 0;
+			}
+
+			.scheduler-main {
+				margin-left: 0;
+			}
+
+			.scheduler-footer {
+				margin-left: 0;
+			}
+		}
+
+		/* Yes/No Badges */
+		.yes-no {
+			display: inline-flex;
+			align-items: center;
+			padding: 0.25em 0.5em;
+			font-size: 0.75rem;
+			font-weight: 500;
+			border-radius: 0.25rem;
+		}
+
+		.yes-no-yes {
+			background-color: #d1e7dd;
+			color: #0f5132;
+		}
+
+		.yes-no-no {
+			background-color: #f8d7da;
+			color: #842029;
+		}
+
+		/* Cards */
+		.card {
+			border: none;
+			box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+			border-radius: 0.5rem;
+		}
+
+		.card-header {
+			background: var(--scheduler-light);
+			border-bottom: 1px solid #dee2e6;
+			font-weight: 600;
+		}
+
+		/* Code blocks */
+		code {
+			background: #f1f3f4;
+			padding: 0.125rem 0.375rem;
+			border-radius: 0.25rem;
+			font-size: 0.875em;
+		}
+
+		pre {
+			background: #f8f9fa;
+			padding: 1rem;
+			border-radius: 0.375rem;
+			border: 1px solid #dee2e6;
+			overflow-x: auto;
+		}
+
+		pre code {
+			background: transparent;
+			padding: 0;
+		}
+
+		/* Collapsible sections */
+		.collapse-icon {
+			transition: transform 0.2s ease;
+		}
+
+		[aria-expanded="true"] .collapse-icon {
+			transform: rotate(90deg);
+		}
+
+		/* Alert styles for running jobs */
+		.alert-job-running {
+			background: linear-gradient(135deg, #fff3cd 0%, #ffeaa7 100%);
+			border: 1px solid #ffc107;
+		}
+
+		/* Schedule next run indicator */
+		.next-run-soon {
+			color: var(--scheduler-success);
+			font-weight: 500;
+		}
+
+		.next-run-canceled {
+			text-decoration: line-through;
+			color: var(--scheduler-secondary);
+		}
+	</style>
+
+	<?= $this->fetch('meta') ?>
+	<?= $this->fetch('css') ?>
+</head>
+<body>
+	<!-- Navbar -->
+	<nav class="navbar navbar-expand-lg navbar-dark scheduler-navbar">
+		<div class="container-fluid">
+			<a class="navbar-brand" href="<?= $this->Url->build(['plugin' => 'QueueScheduler', 'prefix' => 'Admin', 'controller' => 'QueueScheduler', 'action' => 'index']) ?>">
+				<i class="fas fa-calendar-alt me-2"></i>Queue Scheduler
+			</a>
+			<!-- Mobile menu button -->
+			<button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#mobileNav" aria-controls="mobileNav" aria-label="Toggle navigation">
+				<span class="navbar-toggler-icon"></span>
+			</button>
+			<div class="collapse navbar-collapse" id="navbarNav">
+				<ul class="navbar-nav ms-auto">
+					<?php if (\Cake\Core\Plugin::isLoaded('Queue')): ?>
+					<li class="nav-item">
+						<a class="nav-link" href="<?= $this->Url->build(['plugin' => 'Queue', 'prefix' => 'Admin', 'controller' => 'Queue', 'action' => 'index']) ?>">
+							<i class="fas fa-layer-group me-1"></i>Queue Dashboard
+						</a>
+					</li>
+					<?php endif; ?>
+					<li class="nav-item">
+						<span class="nav-link text-light" title="<?= __('Server Time') ?>">
+							<i class="far fa-clock me-1"></i>
+							<?= date('Y-m-d H:i:s') ?>
+						</span>
+					</li>
+				</ul>
+			</div>
+		</div>
+	</nav>
+
+	<!-- Mobile Offcanvas Navigation -->
+	<div class="offcanvas offcanvas-start" tabindex="-1" id="mobileNav" aria-labelledby="mobileNavLabel" style="background: linear-gradient(135deg, #4a2c6a 0%, #2d1a42 100%);">
+		<div class="offcanvas-header border-bottom border-secondary">
+			<h5 class="offcanvas-title text-white" id="mobileNavLabel">
+				<i class="fas fa-calendar-alt me-2"></i>Queue Scheduler
+			</h5>
+			<button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+		</div>
+		<div class="offcanvas-body p-0">
+			<?= $this->element('QueueScheduler.QueueScheduler/mobile_nav') ?>
+		</div>
+	</div>
+
+	<div class="d-flex">
+		<!-- Sidebar -->
+		<?= $this->element('QueueScheduler.QueueScheduler/sidebar') ?>
+
+		<!-- Main Content -->
+		<main class="scheduler-main flex-grow-1">
+			<!-- Flash Messages -->
+			<div class="scheduler-flash">
+				<?= $this->Flash->render() ?>
+			</div>
+
+			<?= $this->fetch('content') ?>
+		</main>
+	</div>
+
+	<!-- Footer -->
+	<footer class="scheduler-footer">
+		<div class="d-flex justify-content-between align-items-center">
+			<span>QueueScheduler Plugin for CakePHP</span>
+			<span>
+				<i class="fas fa-server me-1"></i>
+				PHP <?= phpversion() ?>
+			</span>
+		</div>
+	</footer>
+
+	<?= $this->fetch('postLink') ?>
+
+	<!-- Bootstrap 5.3.3 JS Bundle -->
+	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+
+	<script>
+		document.addEventListener('DOMContentLoaded', function() {
+			// Initialize tooltips
+			var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+			var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+				return new bootstrap.Tooltip(tooltipTriggerEl);
+			});
+
+			// Confirmation dialogs for postLink forms
+			document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
+				form.addEventListener('submit', function(e) {
+					if (!confirm(this.dataset.confirmMessage)) {
+						e.preventDefault();
+					}
+				});
+			});
+
+			<?php if ($autoRefresh > 0): ?>
+			// Auto-refresh
+			setTimeout(function() {
+				window.location.reload();
+			}, <?= $autoRefresh * 1000 ?>);
+			<?php endif; ?>
+		});
+	</script>
+
+	<?= $this->fetch('script') ?>
+</body>
+</html>


### PR DESCRIPTION
## Summary

This PR introduces a modern, self-contained admin dashboard for the QueueScheduler plugin, similar to what was done in cakephp-queue PRs #461 and #464.

### Key Features

- **Bootstrap 5.3.3 + Font Awesome 6.7.2** via CDN with SRI hashes
- **Isolated base controller** (`QueueSchedulerAppController`) that extends `App\Controller\AppController` by default
- **Configuration-driven layout** - can be enabled/disabled via `Configure::read('QueueScheduler.adminLayout')`
- **Standalone mode** - set `QueueScheduler.standalone` to `true` for isolated admin that doesn't depend on the host app
- **Backwards compatible** - existing setup continues to work; new layout is opt-in (default)

### New Files

**Controller:**
- `src/Controller/Admin/QueueSchedulerAppController.php` - Base controller with standalone mode support

**Layout:**
- `templates/layout/queue_scheduler.php` - Self-contained layout with CDN assets

**Elements:**
- `templates/element/QueueScheduler/sidebar.php` - Sidebar navigation
- `templates/element/QueueScheduler/mobile_nav.php` - Mobile navigation
- `templates/element/flash/*.php` - Bootstrap 5 flash messages

### Configuration Options

```php
'QueueScheduler' => [
    'adminLayout' => null,        // null = plugin layout (default), false = app layout, string = custom
    'standalone' => false,        // true = isolated admin without app's AppController
    'dashboardAutoRefresh' => 0,  // Auto-refresh in seconds (0 = disabled)
],
```

### Screenshots

The admin interface now has a modern look with a purple-themed sidebar, consistent with the Queue plugin's design language but with its own identity.