### PR TITLE
Make admin UI CSP-compatible (nonce inline scripts, drop inline onclick)

### DIFF
--- a/templates/Admin/QueueScheduler/index.php
+++ b/templates/Admin/QueueScheduler/index.php
@@ -110,18 +110,21 @@
 								</td>
 								<td class="actions text-end">
 									<?php if (!$queuedJob) { ?>
-										<?= $this->Form->postLink(
+										<?= $this->Form->postButton(
 											'<i class="fas fa-play-circle"></i>',
 											['controller' => 'SchedulerRows', 'action' => 'run', $schedulerRow->id],
 											[
 												'escapeTitle' => false,
 												'class' => 'btn btn-sm btn-success me-1',
 												'title' => __('Run manually now'),
-												'confirm' => __('Sure to run it now?'),
+												'form' => [
+													'class' => 'd-inline',
+													'data-confirm-message' => __('Sure to run it now?'),
+												],
 											],
 										) ?>
 									<?php } ?>
-									<?= $this->Form->postLink(
+									<?= $this->Form->postButton(
 										'<i class="fas fa-times"></i>',
 										['controller' => 'SchedulerRows', 'action' => 'edit', $schedulerRow->id],
 										[
@@ -129,7 +132,10 @@
 											'escapeTitle' => false,
 											'class' => 'btn btn-sm btn-danger',
 											'title' => __('Disable'),
-											'confirm' => __('Sure to disable?'),
+											'form' => [
+												'class' => 'd-inline',
+												'data-confirm-message' => __('Sure to disable?'),
+											],
 										],
 									) ?>
 								</td>
@@ -147,14 +153,16 @@
 			['controller' => 'SchedulerRows', 'action' => 'index'],
 			['class' => 'btn btn-secondary me-2', 'escape' => false],
 		) ?>
-		<?= $this->Form->postLink(
+		<?= $this->Form->postButton(
 			'<i class="fas fa-times me-1"></i>' . __('Disable All'),
 			['controller' => 'SchedulerRows', 'action' => 'disableAll'],
 			[
 				'escapeTitle' => false,
 				'class' => 'btn btn-danger',
-				'confirm' => __('Sure to disable all?'),
-				'block' => true,
+				'form' => [
+					'class' => 'd-inline',
+					'data-confirm-message' => __('Sure to disable all?'),
+				],
 			],
 		) ?>
 	</div>

--- a/templates/Admin/SchedulerRows/edit.php
+++ b/templates/Admin/SchedulerRows/edit.php
@@ -15,10 +15,17 @@
 				['action' => 'index'],
 				['class' => 'btn btn-secondary me-2', 'escape' => false],
 			) ?>
-			<?= $this->Form->postLink(
+			<?= $this->Form->postButton(
 				'<i class="fas fa-trash me-1"></i>' . __('Delete'),
 				['action' => 'delete', $row->id],
-				['class' => 'btn btn-danger me-2', 'escape' => false, 'confirm' => __('Are you sure you want to delete # {0}?', $row->id)],
+				[
+					'class' => 'btn btn-danger me-2',
+					'escape' => false,
+					'form' => [
+						'class' => 'd-inline',
+						'data-confirm-message' => __('Are you sure you want to delete # {0}?', $row->id),
+					],
+				],
 			) ?>
 			<?= $this->Html->link(
 				'<i class="fas fa-clock me-1"></i>' . __('Intervals Help'),

--- a/templates/Admin/SchedulerRows/index.php
+++ b/templates/Admin/SchedulerRows/index.php
@@ -73,14 +73,17 @@
 											<i class="fas fa-exclamation-triangle"></i>
 										</span>
 									<?php } elseif (!$row->enabled && !($row->type === $row::TYPE_SHELL_COMMAND && !\Cake\Core\Configure::read('QueueScheduler.allowRaw'))) { ?>
-										<?= $this->Form->postLink(
+										<?= $this->Form->postButton(
 											'<i class="fas fa-check me-1"></i>' . __('Enable'),
 											['action' => 'edit', $row->id],
 											[
 												'data' => ['enabled' => 1],
 												'escapeTitle' => false,
 												'class' => 'btn btn-sm btn-success',
-												'confirm' => __('Sure to enable?'),
+												'form' => [
+													'class' => 'd-inline',
+													'data-confirm-message' => __('Sure to enable?'),
+												],
 											],
 										) ?>
 									<?php } ?>
@@ -124,15 +127,31 @@
 										['action' => 'edit', $row->id],
 										['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-secondary me-1', 'title' => __('Edit')],
 									) ?>
-									<?= $this->Form->postLink(
+									<?= $this->Form->postButton(
 										'<i class="fas fa-play-circle"></i>',
 										['action' => 'run', $row->id],
-										['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-success me-1', 'title' => __('Run manually now'), 'confirm' => __('Sure to run it now?')],
+										[
+											'escapeTitle' => false,
+											'class' => 'btn btn-sm btn-outline-success me-1',
+											'title' => __('Run manually now'),
+											'form' => [
+												'class' => 'd-inline',
+												'data-confirm-message' => __('Sure to run it now?'),
+											],
+										],
 									) ?>
-									<?= $this->Form->postLink(
+									<?= $this->Form->postButton(
 										'<i class="fas fa-trash"></i>',
 										['action' => 'delete', $row->id],
-										['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-danger', 'title' => __('Delete'), 'confirm' => __('Are you sure you want to delete # {0}?', $row->id)],
+										[
+											'escapeTitle' => false,
+											'class' => 'btn btn-sm btn-outline-danger',
+											'title' => __('Delete'),
+											'form' => [
+												'class' => 'd-inline',
+												'data-confirm-message' => __('Are you sure you want to delete # {0}?', $row->id),
+											],
+										],
 									) ?>
 								</td>
 							</tr>

--- a/templates/Admin/SchedulerRows/view.php
+++ b/templates/Admin/SchedulerRows/view.php
@@ -17,15 +17,29 @@
 				['action' => 'edit', $row->id],
 				['class' => 'btn btn-primary me-2', 'escape' => false],
 			) ?>
-			<?= $this->Form->postLink(
+			<?= $this->Form->postButton(
 				'<i class="fas fa-play-circle me-1"></i>' . __('Run Now'),
 				['action' => 'run', $row->id],
-				['class' => 'btn btn-success me-2', 'escape' => false, 'confirm' => __('Are you sure you want to run this now?')],
+				[
+					'class' => 'btn btn-success me-2',
+					'escape' => false,
+					'form' => [
+						'class' => 'd-inline',
+						'data-confirm-message' => __('Are you sure you want to run this now?'),
+					],
+				],
 			) ?>
-			<?= $this->Form->postLink(
+			<?= $this->Form->postButton(
 				'<i class="fas fa-trash me-1"></i>' . __('Delete'),
 				['action' => 'delete', $row->id],
-				['class' => 'btn btn-danger', 'escape' => false, 'confirm' => __('Are you sure you want to delete # {0}?', $row->id)],
+				[
+					'class' => 'btn btn-danger',
+					'escape' => false,
+					'form' => [
+						'class' => 'd-inline',
+						'data-confirm-message' => __('Are you sure you want to delete # {0}?', $row->id),
+					],
+				],
 			) ?>
 		</div>
 	</div>
@@ -72,14 +86,17 @@
 								<?= $this->element('QueueScheduler.yes_no', ['value' => $row->enabled]) ?>
 								<?= $row->enabled ? __('Yes') : __('No') ?>
 								<?php if (!$row->enabled) { ?>
-									<?= $this->Form->postLink(
+									<?= $this->Form->postButton(
 										'<i class="fas fa-check me-1"></i>' . __('Enable'),
 										['action' => 'edit', $row->id],
 										[
 											'data' => ['enabled' => 1],
 											'escapeTitle' => false,
 											'class' => 'btn btn-sm btn-success ms-2',
-											'confirm' => __('Sure to enable?'),
+											'form' => [
+												'class' => 'd-inline',
+												'data-confirm-message' => __('Sure to enable?'),
+											],
 										],
 									) ?>
 								<?php } ?>

--- a/templates/element/content_autocomplete.php
+++ b/templates/element/content_autocomplete.php
@@ -10,7 +10,8 @@ $scheduler = $this->Scheduler;
 ?>
 <?= $scheduler->contentDatalists() ?>
 <?= $scheduler->frequencyDatalist() ?>
-<script>
+<?php $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', ''); ?>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 document.addEventListener('DOMContentLoaded', function() {
 	var typeField = document.getElementById('type');
 	var contentField = document.getElementById('content');

--- a/templates/element/quick_add.php
+++ b/templates/element/quick_add.php
@@ -34,7 +34,8 @@ $tasks = $scheduler->availableQueueTasks();
 		<div class="form-text"><?= __('Select a command or task to pre-fill the form') ?></div>
 	</div>
 </div>
-<script>
+<?php $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', ''); ?>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 document.addEventListener('DOMContentLoaded', function() {
 	var searchInput = document.getElementById('quick-add-search');
 	if (!searchInput) return;

--- a/templates/layout/queue_scheduler.php
+++ b/templates/layout/queue_scheduler.php
@@ -15,6 +15,8 @@ $request = $this->getRequest();
 if ($request && $request->getParam('controller') === 'QueueScheduler' && $request->getParam('action') === 'index') {
 	$autoRefresh = (int)Configure::read('QueueScheduler.dashboardAutoRefresh') ?: 0;
 }
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
+$nonceAttr = $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '';
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -404,7 +406,7 @@ if ($request && $request->getParam('controller') === 'QueueScheduler' && $reques
 	<!-- Bootstrap 5.3.3 JS Bundle -->
 	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 
-	<script>
+	<script<?= $nonceAttr ?>>
 		document.addEventListener('DOMContentLoaded', function() {
 			// Initialize tooltips
 			var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
@@ -412,7 +414,7 @@ if ($request && $request->getParam('controller') === 'QueueScheduler' && $reques
 				return new bootstrap.Tooltip(tooltipTriggerEl);
 			});
 
-			// Confirmation dialogs for postLink forms
+			// Confirmation dialogs for postButton forms (CSP-safe replacement for postLink + confirm)
 			document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
 				form.addEventListener('submit', function(e) {
 					if (!confirm(this.dataset.confirmMessage)) {


### PR DESCRIPTION
## Summary

- Add `nonce` attribute to the three inline `<script>` blocks (layout tooltip-init / confirm-dialog-delegate / auto-refresh, quick-add element, content-autocomplete element) so apps with a strict `script-src 'self' 'nonce-...' ...` CSP can run them.
- Replace every `Form->postLink` with `Form->postButton` across the admin templates (9 calls across 4 files). Move each `'confirm'` option to a `form[data-confirm-message]` data attribute, handled by the delegated submit listener already present in the layout DOMContentLoaded block.

## Motivation

`postLink` emits `onclick="document.getElementById('post_X').submit()"` on the `<a>`, which CSP blocks without `'unsafe-inline'` / `'unsafe-hashes'`. The `nonce` directive does **not** cover inline event handlers per the CSP spec — only inline `<script>`/`<style>` blocks. `postButton` emits a `<form>` + `<button type="submit">` — zero inline event handlers.

Also: passing `'confirm' => X` to `postButton` re-introduces an inline `onclick` on the button (same code path as postLink), so the confirm message has to migrate to a `data-*` attribute and a delegated submit handler.

The layout already had a `form[data-confirm-message]` submit delegate inside its DOMContentLoaded block — this PR just wires every admin action into it and adds the nonce so the delegate itself runs under strict CSP.

## Before / after

```diff
- <?= $this->Form->postLink(
-     '<i class="fas fa-trash me-1"></i>' . __('Delete'),
-     ['action' => 'delete', $row->id],
-     ['class' => 'btn btn-danger', 'escape' => false, 'confirm' => __('Are you sure you want to delete # {0}?', $row->id)],
- ) ?>
+ <?= $this->Form->postButton(
+     '<i class="fas fa-trash me-1"></i>' . __('Delete'),
+     ['action' => 'delete', $row->id],
+     [
+         'class' => 'btn btn-danger',
+         'escape' => false,
+         'form' => [
+             'class' => 'd-inline',
+             'data-confirm-message' => __('Are you sure you want to delete # {0}?', $row->id),
+         ],
+     ]
+ ) ?>
```

And the nonce on the layout script:

```diff
- <script>
+ <script<?= $nonceAttr ?>>
      document.addEventListener('DOMContentLoaded', function() {
          ...
          document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
              form.addEventListener('submit', function(e) {
                  if (!confirm(this.dataset.confirmMessage)) {
                      e.preventDefault();
                  }
              });
          });
          ...
      });
  </script>
```

## Host app nonce setup

Apps that want to benefit from the new nonce support need to set a `cspNonce` request attribute in a middleware, for example:

```php
$nonce = base64_encode(random_bytes(16));
$request = $request->withAttribute('cspNonce', $nonce);
$response = $response->withHeader(
    'Content-Security-Policy',
    "script-src 'self' 'nonce-{$nonce}'"
);
```

If no `cspNonce` attribute is present, the `<script>` tags fall back to rendering without the `nonce` attribute — apps on permissive CSP continue to work unchanged.

## Visual side-note

The SchedulerRows index action column had multiple adjacent postLinks (run / delete per row). Because `postButton` now wraps each button in `<form class="d-inline">`, if any app relied on a Bootstrap `.btn-group` collapsing borders across them, that visual grouping is lost. Functionally identical; just flagging.

## Verified

- Template grep: 0 `Form->postLink` calls, 0 inline `on*=` event handlers, 0 un-nonced inline `<script>` blocks.
- Behaviour unchanged: all destructive actions still prompt before firing the POST.