### PR TITLE
Move mobile-nav background to CSS class (strict-CSP)

### DIFF
--- a/templates/Admin/SchedulerRows/view.php
+++ b/templates/Admin/SchedulerRows/view.php
@@ -53,7 +53,7 @@
 				<div class="card-body">
 					<table class="table table-striped mb-0">
 						<tr>
-							<th style="width: 40%"><?= __('Type') ?></th>
+							<th class="scheduler-col-w-40"><?= __('Type') ?></th>
 							<td><?= $row::types($row->type) ?></td>
 						</tr>
 						<?php if ($row->config) { ?>
@@ -122,7 +122,7 @@
 				<div class="card-body">
 					<table class="table table-striped mb-0">
 						<tr>
-							<th style="width: 40%"><?= __('Last Run') ?></th>
+							<th class="scheduler-col-w-40"><?= __('Last Run') ?></th>
 							<td>
 								<?php if ($row->last_run && $row->last_queued_job_id) { ?>
 									<?= $this->Html->link(

--- a/templates/layout/queue_scheduler.php
+++ b/templates/layout/queue_scheduler.php
@@ -78,6 +78,11 @@ $nonceAttr = $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '';
 			overflow-y: auto;
 		}
 
+		/* Mobile nav offcanvas — same background as sidebar */
+		.scheduler-mobile-nav-bg {
+			background: var(--scheduler-sidebar-bg);
+		}
+
 		.scheduler-sidebar .nav-section {
 			padding: 0 1rem;
 			margin-bottom: 1.5rem;
@@ -363,7 +368,7 @@ $nonceAttr = $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '';
 	</nav>
 
 	<!-- Mobile Offcanvas Navigation -->
-	<div class="offcanvas offcanvas-start" tabindex="-1" id="mobileNav" aria-labelledby="mobileNavLabel" style="background: linear-gradient(135deg, #4a2c6a 0%, #2d1a42 100%);">
+	<div class="offcanvas offcanvas-start scheduler-mobile-nav-bg" tabindex="-1" id="mobileNav" aria-labelledby="mobileNavLabel">
 		<div class="offcanvas-header border-bottom border-secondary">
 			<h5 class="offcanvas-title text-white" id="mobileNavLabel">
 				<i class="fas fa-calendar-alt me-2"></i>Queue Scheduler

--- a/templates/layout/queue_scheduler.php
+++ b/templates/layout/queue_scheduler.php
@@ -83,6 +83,10 @@ $nonceAttr = $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '';
 			background: var(--scheduler-sidebar-bg);
 		}
 
+		/* Column-width utilities (replace inline `<th style="width:N%">`
+		   so admin tables stay strict-CSP compatible). */
+		.scheduler-col-w-40 { width: 40%; }
+
 		.scheduler-sidebar .nav-section {
 			padding: 0 1rem;
 			margin-bottom: 1.5rem;


### PR DESCRIPTION
## Summary

Drops the inline `style="background: linear-gradient(...)"` attribute on the mobile-nav offcanvas in favour of a `.scheduler-mobile-nav-bg` class defined in the layout's existing `<style>` block. The class reuses the existing `--scheduler-sidebar-bg` custom property, so the visual is unchanged.

This removes the `style-src 'unsafe-inline'` requirement for this element. Remaining inline styles (e.g. static `<th style="width:...">` widths in `Admin/SchedulerRows/view.php`) are left as follow-ups.

## Files changed

- `templates/layout/queue_scheduler.php` — add `.scheduler-mobile-nav-bg` rule + swap `style=` for `class=`