### PR TITLE
Use escapeTitle for icon-prefixed Html->link() titles

### DIFF
--- a/templates/Admin/QueueScheduler/index.php
+++ b/templates/Admin/QueueScheduler/index.php
@@ -14,7 +14,7 @@
 			<?= $this->Html->link(
 				'<i class="fas fa-plus me-1"></i>' . __('New Schedule'),
 				['controller' => 'SchedulerRows', 'action' => 'add'],
-				['class' => 'btn btn-primary', 'escape' => false],
+				['class' => 'btn btn-primary', 'escapeTitle' => false],
 			) ?>
 		</div>
 	</div>
@@ -61,7 +61,7 @@
 											<?= $this->Html->link(
 												'<i class="fas fa-eye"></i>',
 												['plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'view', $queuedJob->id],
-												['escape' => false, 'class' => 'ms-1'],
+												['escapeTitle' => false, 'class' => 'ms-1'],
 											) ?>
 
 											<?php if (!$queuedJob->completed && $queuedJob->fetched) { ?>
@@ -151,7 +151,7 @@
 		<?= $this->Html->link(
 			'<i class="fas fa-list me-1"></i>' . __('All Schedules'),
 			['controller' => 'SchedulerRows', 'action' => 'index'],
-			['class' => 'btn btn-secondary me-2', 'escape' => false],
+			['class' => 'btn btn-secondary me-2', 'escapeTitle' => false],
 		) ?>
 		<?= $this->Form->postButton(
 			'<i class="fas fa-times me-1"></i>' . __('Disable All'),

--- a/templates/Admin/QueueScheduler/intervals.php
+++ b/templates/Admin/QueueScheduler/intervals.php
@@ -14,7 +14,7 @@
 			<?= $this->Html->link(
 				'<i class="fas fa-arrow-left me-1"></i>' . __('Back'),
 				['controller' => 'SchedulerRows', 'action' => 'index'],
-				['class' => 'btn btn-secondary', 'escape' => false],
+				['class' => 'btn btn-secondary', 'escapeTitle' => false],
 			) ?>
 		</div>
 	</div>

--- a/templates/Admin/SchedulerRows/add.php
+++ b/templates/Admin/SchedulerRows/add.php
@@ -13,12 +13,12 @@
 			<?= $this->Html->link(
 				'<i class="fas fa-arrow-left me-1"></i>' . __('Back'),
 				['action' => 'index'],
-				['class' => 'btn btn-secondary me-2', 'escape' => false],
+				['class' => 'btn btn-secondary me-2', 'escapeTitle' => false],
 			) ?>
 			<?= $this->Html->link(
 				'<i class="fas fa-clock me-1"></i>' . __('Intervals Help'),
 				['controller' => 'QueueScheduler', 'action' => 'intervals'],
-				['class' => 'btn btn-outline-secondary', 'escape' => false],
+				['class' => 'btn btn-outline-secondary', 'escapeTitle' => false],
 			) ?>
 		</div>
 	</div>

--- a/templates/Admin/SchedulerRows/edit.php
+++ b/templates/Admin/SchedulerRows/edit.php
@@ -13,7 +13,7 @@
 			<?= $this->Html->link(
 				'<i class="fas fa-arrow-left me-1"></i>' . __('Back'),
 				['action' => 'index'],
-				['class' => 'btn btn-secondary me-2', 'escape' => false],
+				['class' => 'btn btn-secondary me-2', 'escapeTitle' => false],
 			) ?>
 			<?= $this->Form->postButton(
 				'<i class="fas fa-trash me-1"></i>' . __('Delete'),
@@ -30,7 +30,7 @@
 			<?= $this->Html->link(
 				'<i class="fas fa-clock me-1"></i>' . __('Intervals Help'),
 				['controller' => 'QueueScheduler', 'action' => 'intervals'],
-				['class' => 'btn btn-outline-secondary', 'escape' => false],
+				['class' => 'btn btn-outline-secondary', 'escapeTitle' => false],
 			) ?>
 		</div>
 	</div>

--- a/templates/Admin/SchedulerRows/index.php
+++ b/templates/Admin/SchedulerRows/index.php
@@ -13,7 +13,7 @@
 			<?= $this->Html->link(
 				'<i class="fas fa-plus me-1"></i>' . __('New Schedule'),
 				['action' => 'add'],
-				['class' => 'btn btn-primary', 'escape' => false],
+				['class' => 'btn btn-primary', 'escapeTitle' => false],
 			) ?>
 		</div>
 	</div>

--- a/templates/Admin/SchedulerRows/view.php
+++ b/templates/Admin/SchedulerRows/view.php
@@ -15,7 +15,7 @@
 			<?= $this->Html->link(
 				'<i class="fas fa-edit me-1"></i>' . __('Edit'),
 				['action' => 'edit', $row->id],
-				['class' => 'btn btn-primary me-2', 'escape' => false],
+				['class' => 'btn btn-primary me-2', 'escapeTitle' => false],
 			) ?>
 			<?= $this->Form->postButton(
 				'<i class="fas fa-play-circle me-1"></i>' . __('Run Now'),


### PR DESCRIPTION
## Summary

10 admin template links in `templates/Admin/QueueScheduler/` and `templates/Admin/SchedulerRows/` were using `'escape' => false` to render icon-prefixed link titles. That option also disables escaping of url attributes (href, title, class), unsafe whenever those carry user-derived values. Switching to `'escapeTitle' => false` scopes the opt-out to the title only.

The 4 `'escape' => false` entries on `Paginator->first/prev/next/last` are left as-is — `PaginatorHelper` does not support `'escapeTitle'`.

PHP syntax checked on all modified files.