### PR TITLE
Bump branch-alias to 0.3.x-dev; document admin UI config; drop dead crontabMinimum

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
 	"minimum-stability": "stable",
 	"extra": {
 		"branch-alias": {
-			"dev-master": "0.2.x-dev"
+			"dev-master": "0.3.x-dev"
 		}
 	},
 	"scripts": {

--- a/config/app.example.php
+++ b/config/app.example.php
@@ -7,7 +7,6 @@ return [
 		// Additional plugins that are not loaded, but should be included, use `-` prefix to exclude
 		'plugins' => [],
 		'allowRaw' => false, // By default, this is only enabled in debug mode for security reasons.
-		'crontabMinimum' => '1 minute', // By default, this should be run as `* * * * *`
 
 		// Admin Layout configuration:
 		// - null (default): Uses 'QueueScheduler.queue_scheduler' isolated Bootstrap 5 layout

--- a/docs/README.md
+++ b/docs/README.md
@@ -247,6 +247,20 @@ Available icon sets from the Tools plugin:
 
 Without icon configuration, the UI will fall back to text-based labels.
 
+### Admin layout
+
+`QueueScheduler.adminLayout` controls which layout the admin views render in:
+
+- `null` (default) — uses the plugin's isolated `QueueScheduler.queue_scheduler` Bootstrap 5 layout. The admin works without depending on the host app's CSS/JS pipeline.
+- `false` — disables the plugin layout entirely; views fall back to the host app's default layout. Use this when you want the admin to inherit your app chrome.
+- `string` — a specific layout name, e.g. `'AdminTheme.admin'`, when you want to embed the admin in a custom theme.
+
+This is independent of `QueueScheduler.standalone` (which controls whether the admin extends the host's `AppController`); see the Security section for that toggle.
+
+### Dashboard auto-refresh
+
+`QueueScheduler.dashboardAutoRefresh` (integer, seconds; default `0`) sets a meta-refresh interval on the admin dashboard so it polls itself for fresh state without manual reload. `0` disables auto-refresh; a typical value is `30` or `60`.
+
 ### Plugins
 If you want to further include/exclude plugins, you can use the `plugins` key. Use `-` prefix to exclude.
 ```php


### PR DESCRIPTION
Three small pre-release cleanups surfaced by the 1.0-readiness audit:

## 1. `composer.json` branch-alias bump

`dev-master` was aliased to `0.2.x-dev`. With the merged sub-minute work targeting `0.3.0`, the alias should reflect what's actually being developed so Packagist's dev-master listing matches reality.

## 2. Document two undocumented config keys in `docs/README.md`

- `QueueScheduler.adminLayout` (`null` / `false` / `string`) — was only mentioned in passing inside the Security section's standalone-mode discussion. Now has its own Configuration subsection.
- `QueueScheduler.dashboardAutoRefresh` (integer seconds) — was set in `config/app.example.php` and read by `templates/layout/queue_scheduler.php` but never documented. Now has its own subsection alongside `adminLayout`.

## 3. Remove dead `QueueScheduler.crontabMinimum` from `config/app.example.php`

This key has shipped in the example config since early on (`'crontabMinimum' => '1 minute'`) but `grep -rn "crontabMinimum" src/ templates/ docs/` finds zero references. It is read by nothing. Documenting a no-op would mislead users into thinking it constrains scheduling; quietly removing it is the cleaner path.

If this key is reserved for an upcoming feature, restore it in a separate PR with the consuming code so the example config and behavior land together.

## Out of scope (flagged for follow-up)

The 1.0-readiness audit also noted: `README_LOGGING.md` is an untracked aspirational doc in the repo root that should be either deleted or implemented; CI matrix only tests PHP 8.2 and 8.5 despite `>=8.2` requirement; `SchedulerRow::isDue()` / `calculateNextRun()` lack direct unit tests. Not addressed here to keep this PR focused.
