### PR TITLE
Surface scheduler heartbeat on admin index

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"123fa6c9-6818-4a0f-a6af-2e178c322df8","pid":268830,"procStart":"2452640","acquiredAt":1777589447269}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"123fa6c9-6818-4a0f-a6af-2e178c322df8","pid":268830,"procStart":"2452640","acquiredAt":1777589447269}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /.idea/
 .phpcs.cache
 /docs/superpowers/
+/.claude/

--- a/config/app.example.php
+++ b/config/app.example.php
@@ -35,6 +35,20 @@ return [
 
 		// Auto-refresh dashboard (in seconds, 0 = disabled)
 		'dashboardAutoRefresh' => 0,
+
+		// Cache config that the scheduler heartbeat is written to and read
+		// from. The admin index page shows a "Scheduler healthy / stale /
+		// never run" pill based on this.
+		// Defaults to 'default'. For multi-host deployments, point this at
+		// a shared backend (Redis/Memcached) so the web tier can see a
+		// heartbeat written by the CLI tier.
+		//'cacheConfig' => 'default',
+
+		// Maximum age (in seconds) of the heartbeat before the admin page
+		// reports the scheduler as stale. Default 61, which suits the
+		// recommended `* * * * *` cron entry. Raise it if you run cron
+		// less often than every minute.
+		//'healthyWithinSeconds' => 61,
 	],
 	// Icon configuration for the backend UI (optional, but recommended for better UX)
 	// Without this, the UI will use Font Awesome icons from CDN when using the standalone layout.

--- a/config/app.example.php
+++ b/config/app.example.php
@@ -45,10 +45,11 @@ return [
 		//'cacheConfig' => 'default',
 
 		// Maximum age (in seconds) of the heartbeat before the admin page
-		// reports the scheduler as stale. Default 61, which suits the
-		// recommended `* * * * *` cron entry. Raise it if you run cron
-		// less often than every minute.
-		//'healthyWithinSeconds' => 61,
+		// reports the scheduler as stale. Default 65: 60s for the cron
+		// interval plus a few seconds of slack for pass duration and cron
+		// jitter (the heartbeat is written at the *end* of a pass, not the
+		// start). Raise it if you run cron less often than every minute.
+		//'healthyWithinSeconds' => 65,
 	],
 	// Icon configuration for the backend UI (optional, but recommended for better UX)
 	// Without this, the UI will use Font Awesome icons from CDN when using the standalone layout.

--- a/docs/README.md
+++ b/docs/README.md
@@ -261,6 +261,23 @@ This is independent of `QueueScheduler.standalone` (which controls whether the a
 
 `QueueScheduler.dashboardAutoRefresh` (integer, seconds; default `0`) sets a meta-refresh interval on the admin dashboard so it polls itself for fresh state without manual reload. `0` disables auto-refresh; a typical value is `30` or `60`.
 
+### Scheduler health indicator
+
+The admin index page shows a small pill next to the page header indicating whether cron is actively invoking the scheduler:
+
+- **Scheduler healthy** — `bin/cake scheduler run` completed a non-dry-run pass within the threshold window.
+- **Scheduler stale** — last successful pass is older than the threshold; cron has likely stopped firing or the cron entry is misconfigured.
+- **Scheduler: never run** — no heartbeat has been recorded yet (fresh install) or web and CLI are looking at different cache configs.
+
+Internally, `RunCommand` writes a unix timestamp to the cache key `QueueScheduler.lastTick` at the end of every successful pass; the admin controller reads it and compares against the threshold. `--dry-run` deliberately does **not** bump the heartbeat, so smoke-testing a single row will not mask a stalled scheduler.
+
+Two configs control it:
+
+- `QueueScheduler.cacheConfig` (string, default `'default'`) — the CakePHP cache config the heartbeat is written to and read from. Multi-host deployments **must** point this at a shared backend (Redis/Memcached); the default file cache is per-host, so a heartbeat written by the cron host will not be visible from the admin host.
+- `QueueScheduler.healthyWithinSeconds` (int, default `61`) — maximum age of the heartbeat before the page flips to "stale". `61` suits a `* * * * *` cron entry; raise it if you run the scheduler less often (e.g. `*/5 * * * *` would want at least `301`).
+
+A cache backend that is unavailable at read time is treated as "never run" so the page does not 500. Cache write failures inside `RunCommand` are logged at warning level and do not fail the cron.
+
 ### Plugins
 If you want to further include/exclude plugins, you can use the `plugins` key. Use `-` prefix to exclude.
 ```php

--- a/docs/README.md
+++ b/docs/README.md
@@ -274,7 +274,7 @@ Internally, `RunCommand` writes a unix timestamp to the cache key `QueueSchedule
 Two configs control it:
 
 - `QueueScheduler.cacheConfig` (string, default `'default'`) — the CakePHP cache config the heartbeat is written to and read from. Multi-host deployments **must** point this at a shared backend (Redis/Memcached); the default file cache is per-host, so a heartbeat written by the cron host will not be visible from the admin host.
-- `QueueScheduler.healthyWithinSeconds` (int, default `61`) — maximum age of the heartbeat before the page flips to "stale". `61` suits a `* * * * *` cron entry; raise it if you run the scheduler less often (e.g. `*/5 * * * *` would want at least `301`).
+- `QueueScheduler.healthyWithinSeconds` (int, default `65`) — maximum age of the heartbeat before the page flips to "stale". `65` suits a `* * * * *` cron entry: 60 seconds for the interval plus a few seconds of slack for pass duration and cron jitter (the heartbeat is written at the *end* of a pass, not the start). Raise it if you run the scheduler less often — e.g. `*/5 * * * *` would want at least `305`.
 
 A cache backend that is unavailable at read time is treated as "never run" so the page does not 500. Cache write failures inside `RunCommand` are logged at warning level and do not fail the cron.
 

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -2,6 +2,7 @@
 
 namespace QueueScheduler\Command;
 
+use Cake\Cache\Cache;
 use Cake\Collection\Collection;
 use Cake\Command\Command;
 use Cake\Console\Arguments;
@@ -21,6 +22,14 @@ use Throwable;
 class RunCommand extends Command {
 
 	use LogTrait;
+
+	/**
+	 * Cache key holding the unix timestamp of the last successful scheduling
+	 * pass. Read by the admin index page to surface "scheduler is alive".
+	 *
+	 * @var string
+	 */
+	public const HEARTBEAT_KEY = 'QueueScheduler.lastTick';
 
 	/**
 	 * Maximum seconds to wait for the lock before giving up. Tied to the
@@ -256,6 +265,8 @@ class RunCommand extends Command {
 		$scheduled = $scheduler->schedule($events);
 		$failed = $scheduler->lastRunFailureCount();
 
+		$this->writeHeartbeat();
+
 		return ['total' => $total, 'scheduled' => $scheduled, 'failed' => $failed];
 	}
 
@@ -280,6 +291,27 @@ class RunCommand extends Command {
 		}
 
 		return ['events' => $events, 'total' => $uncapped, 'uncapped' => $uncapped, 'capped' => false];
+	}
+
+	/**
+	 * Bump the heartbeat key so the admin UI can tell whether cron is
+	 * still firing. Called only after a real (non-dry-run) pass completes
+	 * — dry runs intentionally don't touch it so smoke tests can't mask a
+	 * stalled scheduler.
+	 *
+	 * Cache write failures are swallowed and logged: heartbeat reporting
+	 * is observability, not the critical path, so a Redis blip must not
+	 * fail the cron.
+	 *
+	 * @return void
+	 */
+	protected function writeHeartbeat(): void {
+		$config = (string)(Configure::read('QueueScheduler.cacheConfig') ?? 'default');
+		try {
+			Cache::write(static::HEARTBEAT_KEY, time(), $config);
+		} catch (Throwable $e) {
+			$this->log(sprintf('Scheduler: heartbeat write failed (%s): %s', $config, $e->getMessage()), 'warning');
+		}
 	}
 
 	/**
@@ -328,6 +360,8 @@ class RunCommand extends Command {
 		$count = $scheduler->schedule($events);
 		$failures = $scheduler->lastRunFailureCount();
 		$heldBack = $total - $count - $failures;
+
+		$this->writeHeartbeat();
 
 		$io->success('Done: ' . $count . ' events scheduled.');
 		if ($heldBack > 0) {

--- a/src/Controller/Admin/QueueSchedulerController.php
+++ b/src/Controller/Admin/QueueSchedulerController.php
@@ -39,14 +39,16 @@ class QueueSchedulerController extends QueueSchedulerAppController {
 
 	/**
 	 * Read the heartbeat written by RunCommand and decide whether the
-	 * scheduler is healthy. Default threshold is 61 seconds (one minute
-	 * of cron slack); apps that run cron less often can raise it via
+	 * scheduler is healthy. Default threshold is 65 seconds: 60s for the
+	 * minutely cron interval plus a few seconds of slack for pass duration
+	 * and cron jitter (the heartbeat is written at the end of a pass, not
+	 * the start). Apps that run cron less often can raise it via
 	 * `QueueScheduler.healthyWithinSeconds`.
 	 *
 	 * @return array{lastTick: int|null, healthy: bool, ageSeconds: int|null, thresholdSeconds: int}
 	 */
 	protected function buildSchedulerStatus(): array {
-		$threshold = (int)(Configure::read('QueueScheduler.healthyWithinSeconds') ?? 61);
+		$threshold = (int)(Configure::read('QueueScheduler.healthyWithinSeconds') ?? 65);
 		$cacheConfig = (string)(Configure::read('QueueScheduler.cacheConfig') ?? 'default');
 
 		$lastTick = null;

--- a/src/Controller/Admin/QueueSchedulerController.php
+++ b/src/Controller/Admin/QueueSchedulerController.php
@@ -2,12 +2,16 @@
 
 namespace QueueScheduler\Controller\Admin;
 
+use Cake\Cache\Cache;
+use Cake\Core\Configure;
 use Cake\Utility\Hash;
 use Cron\CronExpression;
 use Exception;
 use Locale;
 use Panlatent\CronExpressionDescriptor\ExpressionDescriptor;
+use QueueScheduler\Command\RunCommand;
 use QueueScheduler\Model\Entity\SchedulerRow;
+use Throwable;
 
 class QueueSchedulerController extends QueueSchedulerAppController {
 
@@ -28,7 +32,50 @@ class QueueSchedulerController extends QueueSchedulerAppController {
 			->toArray();
 		$runningJobs = Hash::combine($runningJobs, '{n}.reference', '{n}');
 
-		$this->set(compact('schedulerRows', 'runningJobs'));
+		$schedulerStatus = $this->buildSchedulerStatus();
+
+		$this->set(compact('schedulerRows', 'runningJobs', 'schedulerStatus'));
+	}
+
+	/**
+	 * Read the heartbeat written by RunCommand and decide whether the
+	 * scheduler is healthy. Default threshold is 61 seconds (one minute
+	 * of cron slack); apps that run cron less often can raise it via
+	 * `QueueScheduler.healthyWithinSeconds`.
+	 *
+	 * @return array{lastTick: int|null, healthy: bool, ageSeconds: int|null, thresholdSeconds: int}
+	 */
+	protected function buildSchedulerStatus(): array {
+		$threshold = (int)(Configure::read('QueueScheduler.healthyWithinSeconds') ?? 61);
+		$cacheConfig = (string)(Configure::read('QueueScheduler.cacheConfig') ?? 'default');
+
+		$lastTick = null;
+		try {
+			$value = Cache::read(RunCommand::HEARTBEAT_KEY, $cacheConfig);
+			if (is_int($value)) {
+				$lastTick = $value;
+			}
+		} catch (Throwable) {
+			// Cache backend hiccup — treat as "no signal", same as never-run.
+		}
+
+		if ($lastTick === null) {
+			return [
+				'lastTick' => null,
+				'healthy' => false,
+				'ageSeconds' => null,
+				'thresholdSeconds' => $threshold,
+			];
+		}
+
+		$age = max(0, time() - $lastTick);
+
+		return [
+			'lastTick' => $lastTick,
+			'healthy' => $age <= $threshold,
+			'ageSeconds' => $age,
+			'thresholdSeconds' => $threshold,
+		];
 	}
 
 	/**

--- a/templates/Admin/QueueScheduler/index.php
+++ b/templates/Admin/QueueScheduler/index.php
@@ -3,7 +3,18 @@
  * @var \App\View\AppView $this
  * @var iterable<\QueueScheduler\Model\Entity\SchedulerRow> $schedulerRows
  * @var array<\Queue\Model\Entity\QueuedJob> $runningJobs
+ * @var array{lastTick: int|null, healthy: bool, ageSeconds: int|null, thresholdSeconds: int} $schedulerStatus
  */
+
+if ($schedulerStatus['lastTick'] !== null) {
+	$lastTickDt = (new \Cake\I18n\DateTime())->setTimestamp($schedulerStatus['lastTick']);
+	$relTime = method_exists($this->Time, 'relLengthOfTime')
+		? $this->Time->relLengthOfTime($lastTickDt)
+		: $this->Time->timeAgoInWords($lastTickDt);
+} else {
+	$lastTickDt = null;
+	$relTime = null;
+}
 ?>
 <div class="scheduler-dashboard">
 	<div class="d-flex justify-content-between align-items-center mb-4">
@@ -19,7 +30,34 @@
 		</div>
 	</div>
 
-	<p class="text-muted mb-4"><?= __('Addon to run commands and queue tasks as crontab like database driven schedule.') ?></p>
+	<p class="text-muted mb-2"><?= __('Addon to run commands and queue tasks as crontab like database driven schedule.') ?></p>
+
+	<div class="mb-4">
+		<?php if ($schedulerStatus['lastTick'] === null) { ?>
+			<span
+				class="badge bg-secondary-subtle text-secondary-emphasis border border-secondary-subtle"
+				title="<?= h(__('Cron has not invoked the scheduler yet, or the cache config is not shared between web and CLI.')) ?>"
+			>
+				<i class="fas fa-pause-circle me-1"></i><?= __('Scheduler: never run') ?>
+			</span>
+		<?php } elseif ($schedulerStatus['healthy']) { ?>
+			<span
+				class="badge bg-success-subtle text-success-emphasis border border-success-subtle"
+				title="<?= h(__('Last tick {0}', $lastTickDt ? $this->Time->nice($lastTickDt) : '')) ?>"
+			>
+				<i class="fas fa-check-circle me-1"></i><?= __('Scheduler healthy') ?>
+				<span class="text-muted ms-1">&middot; <?= h($relTime) ?></span>
+			</span>
+		<?php } else { ?>
+			<span
+				class="badge bg-danger-subtle text-danger-emphasis border border-danger-subtle"
+				title="<?= h(__('Last tick was {0}s ago; threshold is {1}s. Check that cron is invoking `bin/cake scheduler run`.', $schedulerStatus['ageSeconds'], $schedulerStatus['thresholdSeconds'])) ?>"
+			>
+				<i class="fas fa-exclamation-triangle me-1"></i><?= __('Scheduler stale') ?>
+				<span class="text-muted ms-1">&middot; <?= h($relTime) ?></span>
+			</span>
+		<?php } ?>
+	</div>
 
 	<div class="card">
 		<div class="card-header">

--- a/tests/TestCase/Command/RunCommandTest.php
+++ b/tests/TestCase/Command/RunCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace QueueScheduler\Test\TestCase\Command;
 
+use Cake\Cache\Cache;
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
 use Cake\Core\Configure;
 use Cake\I18n\DateTime;
@@ -165,6 +166,72 @@ class RunCommandTest extends TestCase {
 
 		$this->assertExitCode(0);
 		$this->assertOutputContains('pcntl extension not loaded');
+	}
+
+	/**
+	 * After a successful pass, the heartbeat key must be present in the
+	 * configured cache so the admin UI can surface "scheduler is alive".
+	 *
+	 * @return void
+	 */
+	public function testRunWritesHeartbeatToCache(): void {
+		Cache::delete(RunCommand::HEARTBEAT_KEY, 'default');
+
+		$before = time();
+		$this->exec('scheduler run');
+		$after = time();
+
+		$this->assertExitCode(0);
+		$lastTick = Cache::read(RunCommand::HEARTBEAT_KEY, 'default');
+		$this->assertIsInt($lastTick);
+		$this->assertGreaterThanOrEqual($before, $lastTick);
+		$this->assertLessThanOrEqual($after, $lastTick);
+	}
+
+	/**
+	 * The heartbeat must respect the QueueScheduler.cacheConfig override so
+	 * apps with a dedicated Redis/Memcached config can route the key there.
+	 *
+	 * @return void
+	 */
+	public function testRunHeartbeatHonorsCacheConfigOverride(): void {
+		Cache::setConfig('queue_scheduler_test', [
+			'className' => 'File',
+			'path' => CACHE,
+			'prefix' => 'queue_scheduler_test_',
+			'duration' => '+5 minutes',
+		]);
+		Configure::write('QueueScheduler.cacheConfig', 'queue_scheduler_test');
+
+		try {
+			Cache::delete(RunCommand::HEARTBEAT_KEY, 'queue_scheduler_test');
+			Cache::delete(RunCommand::HEARTBEAT_KEY, 'default');
+
+			$this->exec('scheduler run');
+
+			$this->assertExitCode(0);
+			$this->assertIsInt(Cache::read(RunCommand::HEARTBEAT_KEY, 'queue_scheduler_test'));
+			$this->assertNull(Cache::read(RunCommand::HEARTBEAT_KEY, 'default'));
+		} finally {
+			Configure::delete('QueueScheduler.cacheConfig');
+			Cache::delete(RunCommand::HEARTBEAT_KEY, 'queue_scheduler_test');
+			Cache::drop('queue_scheduler_test');
+		}
+	}
+
+	/**
+	 * --dry-run must not bump the heartbeat — otherwise smoke-testing a row
+	 * silently masks a stalled scheduler.
+	 *
+	 * @return void
+	 */
+	public function testDryRunDoesNotWriteHeartbeat(): void {
+		Cache::delete(RunCommand::HEARTBEAT_KEY, 'default');
+
+		$this->exec('scheduler run --dry-run');
+
+		$this->assertExitCode(0);
+		$this->assertNull(Cache::read(RunCommand::HEARTBEAT_KEY, 'default'));
 	}
 
 	public function testLoopExitsCleanlyWhenLockHeld(): void {

--- a/tests/TestCase/Controller/Admin/QueueSchedulerControllerTest.php
+++ b/tests/TestCase/Controller/Admin/QueueSchedulerControllerTest.php
@@ -81,7 +81,7 @@ class QueueSchedulerControllerTest extends TestCase {
 
 	/**
 	 * Stale heartbeat (older than the threshold) → unhealthy. Default
-	 * threshold is 61s; this test writes a 5-minute-old timestamp.
+	 * threshold is 65s; this test writes a 5-minute-old timestamp.
 	 *
 	 * @return void
 	 */

--- a/tests/TestCase/Controller/Admin/QueueSchedulerControllerTest.php
+++ b/tests/TestCase/Controller/Admin/QueueSchedulerControllerTest.php
@@ -2,8 +2,11 @@
 
 namespace QueueScheduler\Test\TestCase\Controller\Admin;
 
+use Cake\Cache\Cache;
+use Cake\Core\Configure;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
+use QueueScheduler\Command\RunCommand;
 
 /**
  * @uses \QueueScheduler\Controller\Admin\QueueSchedulerController
@@ -15,12 +18,103 @@ class QueueSchedulerControllerTest extends TestCase {
 	/**
 	 * @return void
 	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Cache::delete(RunCommand::HEARTBEAT_KEY, 'default');
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		Cache::delete(RunCommand::HEARTBEAT_KEY, 'default');
+		Configure::delete('QueueScheduler.healthyWithinSeconds');
+		Configure::delete('QueueScheduler.cacheConfig');
+		parent::tearDown();
+	}
+
+	/**
+	 * @return void
+	 */
 	public function testIndex(): void {
 		$this->disableErrorHandlerMiddleware();
 
 		$this->get(['prefix' => 'Admin', 'plugin' => 'QueueScheduler', 'controller' => 'QueueScheduler', 'action' => 'index']);
 
 		$this->assertResponseCode(200);
+	}
+
+	/**
+	 * No heartbeat written yet → page renders the never-run banner so the
+	 * admin can tell whether cron has ever fired the scheduler.
+	 *
+	 * @return void
+	 */
+	public function testIndexExposesNeverRunSchedulerStatus(): void {
+		$this->disableErrorHandlerMiddleware();
+
+		$this->get(['prefix' => 'Admin', 'plugin' => 'QueueScheduler', 'controller' => 'QueueScheduler', 'action' => 'index']);
+
+		$this->assertResponseCode(200);
+		$status = $this->viewVariable('schedulerStatus');
+		$this->assertIsArray($status);
+		$this->assertNull($status['lastTick']);
+		$this->assertFalse($status['healthy']);
+	}
+
+	/**
+	 * Fresh heartbeat (within the configured window) → healthy.
+	 *
+	 * @return void
+	 */
+	public function testIndexExposesHealthyWhenHeartbeatIsRecent(): void {
+		Cache::write(RunCommand::HEARTBEAT_KEY, time() - 10, 'default');
+		$this->disableErrorHandlerMiddleware();
+
+		$this->get(['prefix' => 'Admin', 'plugin' => 'QueueScheduler', 'controller' => 'QueueScheduler', 'action' => 'index']);
+
+		$this->assertResponseCode(200);
+		$status = $this->viewVariable('schedulerStatus');
+		$this->assertIsArray($status);
+		$this->assertTrue($status['healthy']);
+	}
+
+	/**
+	 * Stale heartbeat (older than the threshold) → unhealthy. Default
+	 * threshold is 61s; this test writes a 5-minute-old timestamp.
+	 *
+	 * @return void
+	 */
+	public function testIndexExposesUnhealthyWhenHeartbeatIsStale(): void {
+		Cache::write(RunCommand::HEARTBEAT_KEY, time() - 300, 'default');
+		$this->disableErrorHandlerMiddleware();
+
+		$this->get(['prefix' => 'Admin', 'plugin' => 'QueueScheduler', 'controller' => 'QueueScheduler', 'action' => 'index']);
+
+		$this->assertResponseCode(200);
+		$status = $this->viewVariable('schedulerStatus');
+		$this->assertIsArray($status);
+		$this->assertFalse($status['healthy']);
+		$this->assertSame(300, $status['ageSeconds']);
+	}
+
+	/**
+	 * The threshold must be tunable so deployments running cron less
+	 * often than every minute can still report as healthy.
+	 *
+	 * @return void
+	 */
+	public function testIndexHonorsHealthyWithinSecondsOverride(): void {
+		Configure::write('QueueScheduler.healthyWithinSeconds', 600);
+		Cache::write(RunCommand::HEARTBEAT_KEY, time() - 300, 'default');
+		$this->disableErrorHandlerMiddleware();
+
+		$this->get(['prefix' => 'Admin', 'plugin' => 'QueueScheduler', 'controller' => 'QueueScheduler', 'action' => 'index']);
+
+		$this->assertResponseCode(200);
+		$status = $this->viewVariable('schedulerStatus');
+		$this->assertIsArray($status);
+		$this->assertTrue($status['healthy']);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Adds a small "Scheduler healthy / stale / never run" pill to the admin index page so operators can tell at a glance whether cron is still firing `bin/cake scheduler run`.

`RunCommand` now writes a unix timestamp to the cache key `QueueScheduler.lastTick` at the end of every successful non-dry-run pass. The admin controller reads it and compares against a configurable threshold (default 61s, matching a per-minute cron entry). Mirrors the heartbeat pattern the Queue plugin uses for workers, but lighter — single key, no schema, no migration.

## Configuration

Two new optional keys (both documented in `app.example.php` and `docs/README.md`):

- `QueueScheduler.cacheConfig` (default `'default'`) — which CakePHP cache config to read/write the heartbeat from. Multi-host deployments should point this at a shared backend (Redis/Memcached); the default file cache is per-host.
- `QueueScheduler.healthyWithinSeconds` (default `61`) — max heartbeat age before the pill flips to "stale".

## Behavior notes

- `--dry-run` deliberately does **not** bump the heartbeat — smoke-testing one row should never mask a stalled scheduler.
- Cache write failures inside `RunCommand` are logged at warning level and swallowed; heartbeat reporting is observability and must not fail the cron path.
- Cache backends that throw on read are treated as "never run" so the admin page does not 500.
- No DB schema changes, no new migrations, no new dependencies.
