### PR TITLE
Fix pagination icons rendering as raw text

### DIFF
--- a/templates/element/pagination.php
+++ b/templates/element/pagination.php
@@ -25,11 +25,11 @@ $this->Paginator->setTemplates([
 ?>
 <nav class="mt-3" aria-label="<?= __('Page navigation') ?>">
 	<ul class="pagination justify-content-center mb-2">
-		<?= $this->Paginator->first('<i class="fas fa-angle-double-left"></i>', ['escapeTitle' => false]) ?>
-		<?= $this->Paginator->prev('<i class="fas fa-angle-left"></i>', ['escapeTitle' => false]) ?>
+		<?= $this->Paginator->first('<i class="fas fa-angle-double-left"></i>', ['escape' => false]) ?>
+		<?= $this->Paginator->prev('<i class="fas fa-angle-left"></i>', ['escape' => false]) ?>
 		<?= $this->Paginator->numbers() ?>
-		<?= $this->Paginator->next('<i class="fas fa-angle-right"></i>', ['escapeTitle' => false]) ?>
-		<?= $this->Paginator->last('<i class="fas fa-angle-double-right"></i>', ['escapeTitle' => false]) ?>
+		<?= $this->Paginator->next('<i class="fas fa-angle-right"></i>', ['escape' => false]) ?>
+		<?= $this->Paginator->last('<i class="fas fa-angle-double-right"></i>', ['escape' => false]) ?>
 	</ul>
 	<p class="text-center text-muted small mb-0">
 		<?= $this->Paginator->counter(__('Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total')) ?>


### PR DESCRIPTION
## Summary

`PaginatorHelper` only honors `'escape' => false` — `'escapeTitle' => false` is silently ignored. The FontAwesome `<i>` tags in the pagination element fell back to the default escaped path and rendered as literal HTML text.

## Fix

Revert the four `'escapeTitle' => false` to `'escape' => false`. Verified in CakePHP source: `PaginatorHelper::prev/next/first/last/sort` all use only the `escape` option.