### PR TITLE
Use plugin-specific i18n domain for translations

### DIFF
--- a/resources/locales/queue_scheduler.pot
+++ b/resources/locales/queue_scheduler.pot
@@ -1,0 +1,427 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2026-05-04 02:23+0200\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+msgid "QueueScheduler admin backend is not configured. Set QueueScheduler.adminAccess to a Closure that returns true for permitted callers."
+msgstr ""
+
+msgid "QueueScheduler admin access denied."
+msgstr ""
+
+msgid "Invalid interval"
+msgstr ""
+
+msgid "The row has been saved."
+msgstr ""
+
+msgid "The row could not be saved. Please, try again."
+msgstr ""
+
+msgid "The job has been added to the queue."
+msgstr ""
+
+msgid "The job could not be added to the queue."
+msgstr ""
+
+msgid "All jobs have been disabled"
+msgstr ""
+
+msgid "No new schedules to run."
+msgstr ""
+
+msgid "Queued {0} new schedule(s)."
+msgstr ""
+
+msgid "Queued {0} new schedule(s); {1} skipped."
+msgstr ""
+
+msgid "The row has been deleted."
+msgstr ""
+
+msgid "The row could not be deleted. Please, try again."
+msgstr ""
+
+msgid "Queue Task"
+msgstr ""
+
+msgid "Cake Command"
+msgstr ""
+
+msgid "Shell Command (raw command execution)"
+msgstr ""
+
+msgid "Every day"
+msgstr ""
+
+msgid "Every {0} days"
+msgstr ""
+
+msgid "Every hour"
+msgstr ""
+
+msgid "Every {0} hours"
+msgstr ""
+
+msgid "Every minute"
+msgstr ""
+
+msgid "Every {0} minutes"
+msgstr ""
+
+msgid "Every {0} seconds"
+msgstr ""
+
+msgid "This name is already in use."
+msgstr ""
+
+msgid "Content does not match the chosen type. Use a Task class (or \"Plugin.Task\" alias) for Queue tasks, a Command class (or \"Plugin.Command\" alias) for Cake commands, or a shell command string."
+msgstr ""
+
+msgid "Param must be a JSON object {…} for Queue tasks or a JSON array […] for Cake commands. Shell commands cannot have a param."
+msgstr ""
+
+msgid "Job Config must be a JSON object with allowed keys only: priority (int 1-10) and group (string)."
+msgstr ""
+
+msgid "Must be a cron expression (\"0 11 * * *\"), an @-shortcut (\"@daily\", \"@minutely\"), a relative interval (\"+30 seconds\"), or an ISO 8601 duration (\"P2D\")."
+msgstr ""
+
+msgid "Cannot have separate param data for shell command."
+msgstr ""
+
+msgid "Shell Command rows require QueueScheduler.allowRaw=true (or debug mode)."
+msgstr ""
+
+msgid "Last run failed"
+msgstr ""
+
+msgid "Last run succeeded"
+msgstr ""
+
+msgid "Available Commands & Tasks"
+msgstr ""
+
+msgid "Queue Scheduler"
+msgstr ""
+
+msgid "New Schedule"
+msgstr ""
+
+msgid "Addon to run commands and queue tasks as crontab like database driven schedule."
+msgstr ""
+
+msgid "Cron has not invoked the scheduler yet, or the cache config is not shared between web and CLI."
+msgstr ""
+
+msgid "Scheduler: never run"
+msgstr ""
+
+msgid "Last tick {0}"
+msgstr ""
+
+msgid "Scheduler healthy"
+msgstr ""
+
+msgid "Last tick was {0} ago; threshold is {1}. Check that cron is invoking `bin/cake scheduler run`."
+msgstr ""
+
+msgid "Scheduler stale"
+msgstr ""
+
+msgid "Currently Scheduled"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "Frequency"
+msgstr ""
+
+msgid "Status"
+msgstr ""
+
+msgid "Actions"
+msgstr ""
+
+msgid "Queued"
+msgstr ""
+
+msgid "Last Run"
+msgstr ""
+
+msgid "Next Run"
+msgstr ""
+
+msgid "overdue"
+msgstr ""
+
+msgid "Run manually now"
+msgstr ""
+
+msgid "Sure to run it now?"
+msgstr ""
+
+msgid "Disable"
+msgstr ""
+
+msgid "Sure to disable?"
+msgstr ""
+
+msgid "No schedules yet."
+msgstr ""
+
+msgid "Create your first schedule"
+msgstr ""
+
+msgid "All Schedules"
+msgstr ""
+
+msgid "Run New ({0})"
+msgstr ""
+
+msgid "Queue all enabled schedules that have never run yet"
+msgstr ""
+
+msgid "Queue {0} new schedule(s) now?"
+msgstr ""
+
+msgid "Disable All"
+msgstr ""
+
+msgid "Sure to disable all?"
+msgstr ""
+
+msgid "Intervals Reference"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+msgid "Cron Shortcuts"
+msgstr ""
+
+msgid "Translate Expression"
+msgstr ""
+
+msgid "Cron Expression"
+msgstr ""
+
+msgid "Translate"
+msgstr ""
+
+msgid "Result"
+msgstr ""
+
+msgid "Requires {0} to be installed."
+msgstr ""
+
+msgid "DateInterval Style"
+msgstr ""
+
+msgid "They either start with a {0} or a {1}. Other values are invalid."
+msgstr ""
+
+msgid "You can also define more complex intervals by chaining:"
+msgstr ""
+
+msgid "PHP Documentation"
+msgstr ""
+
+msgid "Crontab Style"
+msgstr ""
+
+msgid "Add Schedule"
+msgstr ""
+
+msgid "Intervals Help"
+msgstr ""
+
+msgid "Schedule Details"
+msgstr ""
+
+msgid "Job Config (JSON)"
+msgstr ""
+
+msgid "Optional JSON object. Allowed keys: priority (1-10, lower runs sooner; default 5) and group (worker group, matches `cake queue worker --group=...`)."
+msgstr ""
+
+msgid "Save"
+msgstr ""
+
+msgid "Edit Schedule"
+msgstr ""
+
+msgid "Delete"
+msgstr ""
+
+msgid "Are you sure you want to delete # {0}?"
+msgstr ""
+
+msgid "Raw commands are currently configured to be not runnable on non-debug system for security reasons."
+msgstr ""
+
+msgid "Enable"
+msgstr ""
+
+msgid "Sure to enable?"
+msgstr ""
+
+msgid "View"
+msgstr ""
+
+msgid "Edit"
+msgstr ""
+
+msgid "Run Now"
+msgstr ""
+
+msgid "Are you sure you want to run this now?"
+msgstr ""
+
+msgid "Type"
+msgstr ""
+
+msgid "Config"
+msgstr ""
+
+msgid "Job Config"
+msgstr ""
+
+msgid "Enabled"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
+
+msgid "No"
+msgstr ""
+
+msgid "Allow Concurrent"
+msgstr ""
+
+msgid "Timing Information"
+msgstr ""
+
+msgid "Never"
+msgstr ""
+
+msgid "Disabled — won't run"
+msgstr ""
+
+msgid "Created"
+msgstr ""
+
+msgid "Modified"
+msgstr ""
+
+msgid "Content"
+msgstr ""
+
+msgid "Job Statistics"
+msgstr ""
+
+msgid "Total Runs"
+msgstr ""
+
+msgid "Completed"
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Avg Duration"
+msgstr ""
+
+msgid "Recent Executions"
+msgstr ""
+
+msgid "View All in Queue"
+msgstr ""
+
+msgid "No runs recorded yet."
+msgstr ""
+
+msgid "Duration"
+msgstr ""
+
+msgid "Output"
+msgstr ""
+
+msgid "Running"
+msgstr ""
+
+msgid "In progress..."
+msgstr ""
+
+msgid "Show output"
+msgstr ""
+
+msgid "Show error"
+msgstr ""
+
+msgid "Crontab Expression"
+msgstr ""
+
+msgid "If you want to port this into a native crontab line, copy and paste the following:"
+msgstr ""
+
+msgid "Dashboard"
+msgstr ""
+
+msgid "Overview"
+msgstr ""
+
+msgid "Scheduled Jobs"
+msgstr ""
+
+msgid "Reference"
+msgstr ""
+
+msgid "Queue Plugin"
+msgstr ""
+
+msgid "Queue Dashboard"
+msgstr ""
+
+msgid "Queued Jobs"
+msgstr ""
+
+msgid "Commands & Tasks"
+msgstr ""
+
+msgid "Available Commands"
+msgstr ""
+
+msgid "Available Queue Tasks"
+msgstr ""
+
+msgid "Page navigation"
+msgstr ""
+
+msgid "Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total"
+msgstr ""
+
+msgid "Quick Add"
+msgstr ""
+
+msgid "Search commands or tasks..."
+msgstr ""
+
+msgid "Select a command or task to pre-fill the form"
+msgstr ""
+
+msgid "Server Time"
+msgstr ""
+

--- a/src/Controller/Admin/QueueSchedulerAppController.php
+++ b/src/Controller/Admin/QueueSchedulerAppController.php
@@ -81,10 +81,10 @@ class QueueSchedulerAppController extends AppController {
 
 		$gate = Configure::read('QueueScheduler.adminAccess');
 		if (!($gate instanceof Closure)) {
-			throw new ForbiddenException(__('QueueScheduler admin backend is not configured. Set QueueScheduler.adminAccess to a Closure that returns true for permitted callers.'));
+			throw new ForbiddenException(__d('queue_scheduler', 'QueueScheduler admin backend is not configured. Set QueueScheduler.adminAccess to a Closure that returns true for permitted callers.'));
 		}
 		if ($gate($this->request) !== true) {
-			throw new ForbiddenException(__('QueueScheduler admin access denied.'));
+			throw new ForbiddenException(__d('queue_scheduler', 'QueueScheduler admin access denied.'));
 		}
 	}
 

--- a/src/Controller/Admin/QueueSchedulerController.php
+++ b/src/Controller/Admin/QueueSchedulerController.php
@@ -99,7 +99,7 @@ class QueueSchedulerController extends QueueSchedulerAppController {
 				$expression = (new CronExpression(SchedulerRow::normalizeCronExpression((string)$interval)))->getExpression();
 			} catch (Exception $e) {
 				$expression = null;
-				$this->Flash->error(__('Invalid interval') . ': ' . $e->getMessage());
+				$this->Flash->error(__d('queue_scheduler', 'Invalid interval') . ': ' . $e->getMessage());
 			}
 			$result = null;
 			if ($expression && class_exists('Panlatent\CronExpressionDescriptor\ExpressionDescriptor')) {

--- a/src/Controller/Admin/SchedulerRowsController.php
+++ b/src/Controller/Admin/SchedulerRowsController.php
@@ -115,11 +115,11 @@ class SchedulerRowsController extends QueueSchedulerAppController {
 		if ($this->request->is('post')) {
 			$row = $this->SchedulerRows->patchEntity($row, $this->request->getData());
 			if ($this->SchedulerRows->save($row)) {
-				$this->Flash->success(__('The row has been saved.'));
+				$this->Flash->success(__d('queue_scheduler', 'The row has been saved.'));
 
 				return $this->redirect(['action' => 'view', $row->id]);
 			}
-			$this->Flash->error(__('The row could not be saved. Please, try again.'));
+			$this->Flash->error(__d('queue_scheduler', 'The row could not be saved. Please, try again.'));
 		} else {
 			foreach ($this->request->getQueryParams() as $key => $value) {
 				$row->set($key, $value);
@@ -143,11 +143,11 @@ class SchedulerRowsController extends QueueSchedulerAppController {
 		if ($this->request->is(['patch', 'post', 'put'])) {
 			$row = $this->SchedulerRows->patchEntity($row, $this->request->getData());
 			if ($this->SchedulerRows->save($row)) {
-				$this->Flash->success(__('The row has been saved.'));
+				$this->Flash->success(__d('queue_scheduler', 'The row has been saved.'));
 
 				return $this->redirect(['action' => 'view', $id]);
 			}
-			$this->Flash->error(__('The row could not be saved. Please, try again.'));
+			$this->Flash->error(__d('queue_scheduler', 'The row could not be saved. Please, try again.'));
 		}
 		$this->set(compact('row'));
 
@@ -166,8 +166,8 @@ class SchedulerRowsController extends QueueSchedulerAppController {
 		$row = $this->SchedulerRows->get($id);
 		$ok = $this->SchedulerRows->run($row);
 		$message = $ok
-			? __('The job has been added to the queue.')
-			: __('The job could not be added to the queue.');
+			? __d('queue_scheduler', 'The job has been added to the queue.')
+			: __d('queue_scheduler', 'The job could not be added to the queue.');
 
 		if ($this->request->is(['ajax', 'json'])) {
 			return $this->response
@@ -191,7 +191,7 @@ class SchedulerRowsController extends QueueSchedulerAppController {
 		$this->request->allowMethod(['post']);
 		$this->SchedulerRows->updateAll(['enabled' => false], ['enabled' => true]);
 
-		$this->Flash->success(__('All jobs have been disabled'));
+		$this->Flash->success(__d('queue_scheduler', 'All jobs have been disabled'));
 
 		return $this->redirect($this->referer(['action' => 'index']));
 	}
@@ -223,11 +223,11 @@ class SchedulerRowsController extends QueueSchedulerAppController {
 		}
 
 		if ($queued === 0 && $skipped === 0) {
-			$this->Flash->success(__('No new schedules to run.'));
+			$this->Flash->success(__d('queue_scheduler', 'No new schedules to run.'));
 		} elseif ($skipped === 0) {
-			$this->Flash->success(__('Queued {0} new schedule(s).', $queued));
+			$this->Flash->success(__d('queue_scheduler', 'Queued {0} new schedule(s).', $queued));
 		} else {
-			$this->Flash->success(__('Queued {0} new schedule(s); {1} skipped.', $queued, $skipped));
+			$this->Flash->success(__d('queue_scheduler', 'Queued {0} new schedule(s); {1} skipped.', $queued, $skipped));
 		}
 
 		return $this->redirect($this->referer(['action' => 'index']));
@@ -244,9 +244,9 @@ class SchedulerRowsController extends QueueSchedulerAppController {
 		$this->request->allowMethod(['post', 'delete']);
 		$row = $this->SchedulerRows->get($id);
 		if ($this->SchedulerRows->delete($row)) {
-			$this->Flash->success(__('The row has been deleted.'));
+			$this->Flash->success(__d('queue_scheduler', 'The row has been deleted.'));
 		} else {
-			$this->Flash->error(__('The row could not be deleted. Please, try again.'));
+			$this->Flash->error(__d('queue_scheduler', 'The row could not be deleted. Please, try again.'));
 		}
 
 		return $this->redirect(['action' => 'index']);

--- a/src/Model/Entity/SchedulerRow.php
+++ b/src/Model/Entity/SchedulerRow.php
@@ -70,9 +70,9 @@ class SchedulerRow extends Entity {
 	 */
 	public static function types(array|int|null $value = null): array|string {
 		$options = [
-			static::TYPE_QUEUE_TASK => __('Queue Task'),
-			static::TYPE_CAKE_COMMAND => __('Cake Command'),
-			static::TYPE_SHELL_COMMAND => __('Shell Command (raw command execution)'),
+			static::TYPE_QUEUE_TASK => __d('queue_scheduler', 'Queue Task'),
+			static::TYPE_CAKE_COMMAND => __d('queue_scheduler', 'Cake Command'),
+			static::TYPE_SHELL_COMMAND => __d('queue_scheduler', 'Shell Command (raw command execution)'),
 		];
 
 		/** @var array<string, string>|string */

--- a/src/Model/Table/SchedulerRowsTable.php
+++ b/src/Model/Table/SchedulerRowsTable.php
@@ -90,7 +90,7 @@ class SchedulerRowsTable extends Table {
 			->add('name', 'unique', [
 				'rule' => 'validateUniqueName',
 				'provider' => 'table',
-				'message' => __('This name is already in use.'),
+				'message' => __d('queue_scheduler', 'This name is already in use.'),
 			]);
 
 		$validator
@@ -102,7 +102,7 @@ class SchedulerRowsTable extends Table {
 			->notEmptyString('content')
 			->add('content', 'validateContent', [
 				'provider' => 'table',
-				'message' => __('Content does not match the chosen type. Use a Task class (or "Plugin.Task" alias) for Queue tasks, a Command class (or "Plugin.Command" alias) for Cake commands, or a shell command string.'),
+				'message' => __d('queue_scheduler', 'Content does not match the chosen type. Use a Task class (or "Plugin.Task" alias) for Queue tasks, a Command class (or "Plugin.Command" alias) for Cake commands, or a shell command string.'),
 			]);
 
 		$validator
@@ -110,7 +110,7 @@ class SchedulerRowsTable extends Table {
 			->allowEmptyString('param')
 			->add('param', 'validateParam', [
 				'provider' => 'table',
-				'message' => __('Param must be a JSON object {…} for Queue tasks or a JSON array […] for Cake commands. Shell commands cannot have a param.'),
+				'message' => __d('queue_scheduler', 'Param must be a JSON object {…} for Queue tasks or a JSON array […] for Cake commands. Shell commands cannot have a param.'),
 			]);
 
 		$validator
@@ -118,7 +118,7 @@ class SchedulerRowsTable extends Table {
 			->allowEmptyString('job_config')
 			->add('job_config', 'validateJobConfig', [
 				'provider' => 'table',
-				'message' => __('Job Config must be a JSON object with allowed keys only: priority (int 1-10) and group (string).'),
+				'message' => __d('queue_scheduler', 'Job Config must be a JSON object with allowed keys only: priority (int 1-10) and group (string).'),
 			]);
 
 		$validator
@@ -128,7 +128,7 @@ class SchedulerRowsTable extends Table {
 			->notEmptyString('frequency')
 			->add('frequency', 'validateFrequency', [
 				'provider' => 'table',
-				'message' => __('Must be a cron expression ("0 11 * * *"), an @-shortcut ("@daily", "@minutely"), a relative interval ("+30 seconds"), or an ISO 8601 duration ("P2D").'),
+				'message' => __d('queue_scheduler', 'Must be a cron expression ("0 11 * * *"), an @-shortcut ("@daily", "@minutely"), a relative interval ("+30 seconds"), or an ISO 8601 duration ("P2D").'),
 			]);
 
 		$validator
@@ -192,7 +192,7 @@ class SchedulerRowsTable extends Table {
 			case SchedulerRow::TYPE_CAKE_COMMAND:
 				return $this->validateCakeCommandParam($value, $data);
 			case SchedulerRow::TYPE_SHELL_COMMAND:
-				return $value === '' ? true : __('Cannot have separate param data for shell command.');
+				return $value === '' ? true : __d('queue_scheduler', 'Cannot have separate param data for shell command.');
 		}
 
 		return false;
@@ -530,7 +530,7 @@ class SchedulerRowsTable extends Table {
 	 */
 	protected function validateShellCommand(string $value, array $data): string|bool {
 		if (!Configure::read('debug') && !Configure::read('QueueScheduler.allowRaw')) {
-			return __('Shell Command rows require QueueScheduler.allowRaw=true (or debug mode).');
+			return __d('queue_scheduler', 'Shell Command rows require QueueScheduler.allowRaw=true (or debug mode).');
 		}
 
 		return true;

--- a/src/View/Helper/SchedulerHelper.php
+++ b/src/View/Helper/SchedulerHelper.php
@@ -143,13 +143,13 @@ class SchedulerHelper extends Helper {
 			return '';
 		}
 		if ($job->failure_message) {
-			$title = (string)__('Last run failed');
+			$title = (string)__d('queue_scheduler', 'Last run failed');
 
 			return '<i class="fas fa-times-circle text-danger me-1" title="' . h($title)
 				. '" aria-label="' . h($title) . '"></i>';
 		}
 		if ($job->completed) {
-			$title = (string)__('Last run succeeded');
+			$title = (string)__d('queue_scheduler', 'Last run succeeded');
 
 			return '<i class="fas fa-check-circle text-success me-1" title="' . h($title)
 				. '" aria-label="' . h($title) . '"></i>';

--- a/templates/Admin/QueueScheduler/available.php
+++ b/templates/Admin/QueueScheduler/available.php
@@ -6,7 +6,7 @@
 <div class="queue-scheduler-available">
 	<div class="d-flex justify-content-between align-items-center mb-4">
 		<h2 class="mb-0">
-			<i class="fas fa-list me-2"></i><?= __('Available Commands & Tasks') ?>
+			<i class="fas fa-list me-2"></i><?= __d('queue_scheduler', 'Available Commands & Tasks') ?>
 		</h2>
 	</div>
 

--- a/templates/Admin/QueueScheduler/index.php
+++ b/templates/Admin/QueueScheduler/index.php
@@ -19,41 +19,41 @@ if ($schedulerStatus['lastTick'] !== null) {
 <div class="scheduler-dashboard">
 	<div class="d-flex justify-content-between align-items-center mb-4">
 		<h2 class="mb-0">
-			<i class="fas fa-calendar-alt me-2"></i><?= __('Queue Scheduler') ?>
+			<i class="fas fa-calendar-alt me-2"></i><?= __d('queue_scheduler', 'Queue Scheduler') ?>
 		</h2>
 		<div>
 			<?= $this->Html->link(
-				'<i class="fas fa-plus me-1"></i>' . __('New Schedule'),
+				'<i class="fas fa-plus me-1"></i>' . __d('queue_scheduler', 'New Schedule'),
 				['controller' => 'SchedulerRows', 'action' => 'add'],
 				['class' => 'btn btn-primary', 'escapeTitle' => false],
 			) ?>
 		</div>
 	</div>
 
-	<p class="text-muted mb-2"><?= __('Addon to run commands and queue tasks as crontab like database driven schedule.') ?></p>
+	<p class="text-muted mb-2"><?= __d('queue_scheduler', 'Addon to run commands and queue tasks as crontab like database driven schedule.') ?></p>
 
 	<div class="mb-4">
 		<?php if ($schedulerStatus['lastTick'] === null) { ?>
 			<span
 				class="badge bg-secondary-subtle text-secondary-emphasis border border-secondary-subtle"
-				title="<?= h(__('Cron has not invoked the scheduler yet, or the cache config is not shared between web and CLI.')) ?>"
+				title="<?= h(__d('queue_scheduler', 'Cron has not invoked the scheduler yet, or the cache config is not shared between web and CLI.')) ?>"
 			>
-				<i class="fas fa-pause-circle me-1"></i><?= __('Scheduler: never run') ?>
+				<i class="fas fa-pause-circle me-1"></i><?= __d('queue_scheduler', 'Scheduler: never run') ?>
 			</span>
 		<?php } elseif ($schedulerStatus['healthy']) { ?>
 			<span
 				class="badge bg-success-subtle text-success-emphasis border border-success-subtle"
-				title="<?= h(__('Last tick {0}', $lastTickDt ? $this->Time->nice($lastTickDt) : '')) ?>"
+				title="<?= h(__d('queue_scheduler', 'Last tick {0}', $lastTickDt ? $this->Time->nice($lastTickDt) : '')) ?>"
 			>
-				<i class="fas fa-check-circle me-1"></i><?= __('Scheduler healthy') ?>
+				<i class="fas fa-check-circle me-1"></i><?= __d('queue_scheduler', 'Scheduler healthy') ?>
 				<span class="text-muted ms-1">&middot; <?= h($relTime) ?></span>
 			</span>
 		<?php } else { ?>
 			<span
 				class="badge bg-danger-subtle text-danger-emphasis border border-danger-subtle"
-				title="<?= h(__('Last tick was {0} ago; threshold is {1}. Check that cron is invoking `bin/cake scheduler run`.', $this->Scheduler->duration((int)$schedulerStatus['ageSeconds']), $this->Scheduler->duration($schedulerStatus['thresholdSeconds']))) ?>"
+				title="<?= h(__d('queue_scheduler', 'Last tick was {0} ago; threshold is {1}. Check that cron is invoking `bin/cake scheduler run`.', $this->Scheduler->duration((int)$schedulerStatus['ageSeconds']), $this->Scheduler->duration($schedulerStatus['thresholdSeconds']))) ?>"
 			>
-				<i class="fas fa-exclamation-triangle me-1"></i><?= __('Scheduler stale') ?>
+				<i class="fas fa-exclamation-triangle me-1"></i><?= __d('queue_scheduler', 'Scheduler stale') ?>
 				<span class="text-muted ms-1">&middot; <?= h($relTime) ?></span>
 			</span>
 		<?php } ?>
@@ -61,17 +61,17 @@ if ($schedulerStatus['lastTick'] !== null) {
 
 	<div class="card">
 		<div class="card-header">
-			<i class="fas fa-clock me-2"></i><?= __('Currently Scheduled') ?>
+			<i class="fas fa-clock me-2"></i><?= __d('queue_scheduler', 'Currently Scheduled') ?>
 		</div>
 		<div class="card-body p-0">
 			<div class="table-responsive">
 				<table class="table table-hover scheduler-table mb-0">
 					<thead>
 						<tr>
-							<th><?= __('Name') ?></th>
-							<th><?= __('Frequency') ?></th>
-							<th><?= __('Status') ?></th>
-							<th class="actions text-end"><?= __('Actions') ?></th>
+							<th><?= __d('queue_scheduler', 'Name') ?></th>
+							<th><?= __d('queue_scheduler', 'Frequency') ?></th>
+							<th><?= __d('queue_scheduler', 'Status') ?></th>
+							<th class="actions text-end"><?= __d('queue_scheduler', 'Actions') ?></th>
 						</tr>
 					</thead>
 					<tbody>
@@ -104,7 +104,7 @@ if ($schedulerStatus['lastTick'] !== null) {
 										<div class="alert alert-job-running mb-2 p-2">
 											<strong>
 												<?= $this->Html->link(
-													h($queuedJob->status) ?: __('Queued'),
+													h($queuedJob->status) ?: __d('queue_scheduler', 'Queued'),
 													['plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'view', $queuedJob->id],
 												) ?>
 											</strong>
@@ -130,7 +130,7 @@ if ($schedulerStatus['lastTick'] !== null) {
 										<?php $lastJob = $schedulerRow->last_queued_job; ?>
 										<div class="small">
 											<?= $this->Scheduler->runStatusIcon($lastJob) ?>
-											<span class="text-muted"><?= __('Last Run') ?>:</span>
+											<span class="text-muted"><?= __d('queue_scheduler', 'Last Run') ?>:</span>
 											<?php if ($schedulerRow->last_queued_job_id) { ?>
 												<?= $this->Html->link(
 													$this->Time->nice($schedulerRow->last_run),
@@ -155,9 +155,9 @@ if ($schedulerStatus['lastTick'] !== null) {
 									?>
 									<?php if ($nextRun) { ?>
 										<div class="small">
-											<span class="text-muted"><?= __('Next Run') ?>: <?= $this->Time->nice($nextRun) ?></span>
+											<span class="text-muted"><?= __d('queue_scheduler', 'Next Run') ?>: <?= $this->Time->nice($nextRun) ?></span>
 											<span class="<?= $nextRunOverdue ? 'text-danger fw-semibold' : 'text-muted' ?>">
-												<?= $grosslyOverdue ? '(' . __('overdue') . ')' : '(' . h($this->Time->timeAgoInWords($nextRun)) . ')' ?>
+												<?= $grosslyOverdue ? '(' . __d('queue_scheduler', 'overdue') . ')' : '(' . h($this->Time->timeAgoInWords($nextRun)) . ')' ?>
 											</span>
 										</div>
 									<?php } ?>
@@ -170,11 +170,11 @@ if ($schedulerStatus['lastTick'] !== null) {
 											[
 												'escapeTitle' => false,
 												'class' => 'btn btn-sm btn-success me-1',
-												'title' => __('Run manually now'),
-												'aria-label' => __('Run manually now'),
+												'title' => __d('queue_scheduler', 'Run manually now'),
+												'aria-label' => __d('queue_scheduler', 'Run manually now'),
 												'form' => [
 													'class' => 'd-inline js-scheduler-run-form',
-													'data-confirm-message' => __('Sure to run it now?'),
+													'data-confirm-message' => __d('queue_scheduler', 'Sure to run it now?'),
 												],
 											],
 										) ?>
@@ -186,11 +186,11 @@ if ($schedulerStatus['lastTick'] !== null) {
 											'data' => ['enabled' => 0],
 											'escapeTitle' => false,
 											'class' => 'btn btn-sm btn-warning',
-											'title' => __('Disable'),
-											'aria-label' => __('Disable'),
+											'title' => __d('queue_scheduler', 'Disable'),
+											'aria-label' => __d('queue_scheduler', 'Disable'),
 											'form' => [
 												'class' => 'd-inline',
-												'data-confirm-message' => __('Sure to disable?'),
+												'data-confirm-message' => __d('queue_scheduler', 'Sure to disable?'),
 											],
 										],
 									) ?>
@@ -201,9 +201,9 @@ if ($schedulerStatus['lastTick'] !== null) {
 							<tr>
 								<td colspan="4" class="text-center text-muted py-4">
 									<i class="fas fa-calendar-plus mb-2 d-block fs-4" aria-hidden="true"></i>
-									<?= __('No schedules yet.') ?>
+									<?= __d('queue_scheduler', 'No schedules yet.') ?>
 									<?= $this->Html->link(
-										__('Create your first schedule'),
+										__d('queue_scheduler', 'Create your first schedule'),
 										['controller' => 'SchedulerRows', 'action' => 'add'],
 									) ?>
 								</td>
@@ -225,34 +225,34 @@ if ($schedulerStatus['lastTick'] !== null) {
 	?>
 	<div class="mt-3">
 		<?= $this->Html->link(
-			'<i class="fas fa-list me-1"></i>' . __('All Schedules'),
+			'<i class="fas fa-list me-1"></i>' . __d('queue_scheduler', 'All Schedules'),
 			['controller' => 'SchedulerRows', 'action' => 'index'],
 			['class' => 'btn btn-secondary me-2', 'escapeTitle' => false],
 		) ?>
 		<?php if ($newCount >= 2) { ?>
 			<?= $this->Form->postButton(
-				'<i class="fas fa-play-circle me-1"></i>' . __('Run New ({0})', $newCount),
+				'<i class="fas fa-play-circle me-1"></i>' . __d('queue_scheduler', 'Run New ({0})', $newCount),
 				['controller' => 'SchedulerRows', 'action' => 'runAllNew'],
 				[
 					'escapeTitle' => false,
 					'class' => 'btn btn-success me-2',
-					'title' => __('Queue all enabled schedules that have never run yet'),
+					'title' => __d('queue_scheduler', 'Queue all enabled schedules that have never run yet'),
 					'form' => [
 						'class' => 'd-inline',
-						'data-confirm-message' => __('Queue {0} new schedule(s) now?', $newCount),
+						'data-confirm-message' => __d('queue_scheduler', 'Queue {0} new schedule(s) now?', $newCount),
 					],
 				],
 			) ?>
 		<?php } ?>
 		<?= $this->Form->postButton(
-			'<i class="fas fa-pause-circle me-1"></i>' . __('Disable All'),
+			'<i class="fas fa-pause-circle me-1"></i>' . __d('queue_scheduler', 'Disable All'),
 			['controller' => 'SchedulerRows', 'action' => 'disableAll'],
 			[
 				'escapeTitle' => false,
 				'class' => 'btn btn-warning',
 				'form' => [
 					'class' => 'd-inline',
-					'data-confirm-message' => __('Sure to disable all?'),
+					'data-confirm-message' => __d('queue_scheduler', 'Sure to disable all?'),
 				],
 			],
 		) ?>

--- a/templates/Admin/QueueScheduler/intervals.php
+++ b/templates/Admin/QueueScheduler/intervals.php
@@ -8,11 +8,11 @@
 <div class="scheduler-intervals">
 	<div class="d-flex justify-content-between align-items-center mb-4">
 		<h2 class="mb-0">
-			<i class="fas fa-clock me-2"></i><?= __('Intervals Reference') ?>
+			<i class="fas fa-clock me-2"></i><?= __d('queue_scheduler', 'Intervals Reference') ?>
 		</h2>
 		<div>
 			<?= $this->Html->link(
-				'<i class="fas fa-arrow-left me-1"></i>' . __('Back'),
+				'<i class="fas fa-arrow-left me-1"></i>' . __d('queue_scheduler', 'Back'),
 				['controller' => 'SchedulerRows', 'action' => 'index'],
 				['class' => 'btn btn-secondary', 'escapeTitle' => false],
 			) ?>
@@ -23,7 +23,7 @@
 		<div class="col-lg-6 mb-4">
 			<div class="card h-100">
 				<div class="card-header">
-					<i class="fas fa-hashtag me-2"></i><?= __('Cron Shortcuts') ?>
+					<i class="fas fa-hashtag me-2"></i><?= __d('queue_scheduler', 'Cron Shortcuts') ?>
 				</div>
 				<div class="card-body">
 					<ul class="list-unstyled mb-0">
@@ -43,30 +43,30 @@
 		<div class="col-lg-6 mb-4">
 			<div class="card h-100">
 				<div class="card-header">
-					<i class="fas fa-language me-2"></i><?= __('Translate Expression') ?>
+					<i class="fas fa-language me-2"></i><?= __d('queue_scheduler', 'Translate Expression') ?>
 				</div>
 				<div class="card-body">
 					<?php if (class_exists('Panlatent\CronExpressionDescriptor\ExpressionDescriptor')) { ?>
 						<?= $this->Form->create() ?>
 						<div class="mb-3">
 							<?= $this->Form->control('interval', [
-								'label' => __('Cron Expression'),
+								'label' => __d('queue_scheduler', 'Cron Expression'),
 								'placeholder' => '* * * * *',
 								'class' => 'form-control',
 							]) ?>
 						</div>
-						<?= $this->Form->button(__('Translate'), ['class' => 'btn btn-primary']) ?>
+						<?= $this->Form->button(__d('queue_scheduler', 'Translate'), ['class' => 'btn btn-primary']) ?>
 						<?= $this->Form->end() ?>
 
 						<?php if (!empty($result)) { ?>
 							<div class="alert alert-success mt-3 mb-0">
-								<strong><?= __('Result') ?>:</strong> <?= h($result) ?>
+								<strong><?= __d('queue_scheduler', 'Result') ?>:</strong> <?= h($result) ?>
 							</div>
 						<?php } ?>
 					<?php } else { ?>
 						<div class="alert alert-info mb-0">
 							<i class="fas fa-info-circle me-1"></i>
-							<?= __('Requires {0} to be installed.', '<code>panlatent/cron-expression-descriptor</code>') ?>
+							<?= __d('queue_scheduler', 'Requires {0} to be installed.', '<code>panlatent/cron-expression-descriptor</code>') ?>
 						</div>
 					<?php } ?>
 				</div>
@@ -78,19 +78,19 @@
 		<div class="col-lg-6 mb-4">
 			<div class="card h-100">
 				<div class="card-header">
-					<i class="fas fa-calendar-day me-2"></i><?= __('DateInterval Style') ?>
+					<i class="fas fa-calendar-day me-2"></i><?= __d('queue_scheduler', 'DateInterval Style') ?>
 				</div>
 				<div class="card-body">
-					<p><?= __('They either start with a {0} or a {1}. Other values are invalid.', '<code>P</code>', '<code>+</code>') ?></p>
+					<p><?= __d('queue_scheduler', 'They either start with a {0} or a {1}. Other values are invalid.', '<code>P</code>', '<code>+</code>') ?></p>
 					<ul class="mb-3">
 						<li><code>P1D</code> or <code>+ 1 day</code></li>
 						<li><code>P2W</code> or <code>+ 2 weeks</code></li>
 					</ul>
-					<p class="mb-2"><?= __('You can also define more complex intervals by chaining:') ?></p>
+					<p class="mb-2"><?= __d('queue_scheduler', 'You can also define more complex intervals by chaining:') ?></p>
 					<code>+ 1 hour + 5 minutes</code>
 					<p class="mt-3 mb-0">
 						<a href="https://www.php.net/manual/en/dateinterval.createfromdatestring.php" target="_blank" class="btn btn-sm btn-outline-secondary">
-							<i class="fas fa-external-link-alt me-1"></i><?= __('PHP Documentation') ?>
+							<i class="fas fa-external-link-alt me-1"></i><?= __d('queue_scheduler', 'PHP Documentation') ?>
 						</a>
 					</p>
 				</div>
@@ -100,7 +100,7 @@
 		<div class="col-lg-6 mb-4">
 			<div class="card h-100">
 				<div class="card-header">
-					<i class="fas fa-terminal me-2"></i><?= __('Crontab Style') ?>
+					<i class="fas fa-terminal me-2"></i><?= __d('queue_scheduler', 'Crontab Style') ?>
 				</div>
 				<div class="card-body">
 					<pre class="mb-3">*    *    *    *    *   /path/to/command

--- a/templates/Admin/SchedulerRows/add.php
+++ b/templates/Admin/SchedulerRows/add.php
@@ -7,16 +7,16 @@
 <div class="scheduler-rows-add">
 	<div class="d-flex justify-content-between align-items-center mb-4">
 		<h2 class="mb-0">
-			<i class="fas fa-plus me-2"></i><?= __('Add Schedule') ?>
+			<i class="fas fa-plus me-2"></i><?= __d('queue_scheduler', 'Add Schedule') ?>
 		</h2>
 		<div>
 			<?= $this->Html->link(
-				'<i class="fas fa-arrow-left me-1"></i>' . __('Back'),
+				'<i class="fas fa-arrow-left me-1"></i>' . __d('queue_scheduler', 'Back'),
 				['action' => 'index'],
 				['class' => 'btn btn-secondary me-2', 'escapeTitle' => false],
 			) ?>
 			<?= $this->Html->link(
-				'<i class="fas fa-clock me-1"></i>' . __('Intervals Help'),
+				'<i class="fas fa-clock me-1"></i>' . __d('queue_scheduler', 'Intervals Help'),
 				['controller' => 'QueueScheduler', 'action' => 'intervals'],
 				['class' => 'btn btn-outline-secondary', 'escapeTitle' => false],
 			) ?>
@@ -29,7 +29,7 @@
 
 	<div class="card">
 		<div class="card-header">
-			<i class="fas fa-edit me-2"></i><?= __('Schedule Details') ?>
+			<i class="fas fa-edit me-2"></i><?= __d('queue_scheduler', 'Schedule Details') ?>
 		</div>
 		<div class="card-body">
 			<?php
@@ -58,9 +58,9 @@
 					'type' => 'textarea',
 					'rows' => 3,
 					'class' => 'form-control',
-					'label' => __('Job Config (JSON)'),
+					'label' => __d('queue_scheduler', 'Job Config (JSON)'),
 					'placeholder' => '{"priority": 5, "group": "batch"}',
-					'help' => __('Optional JSON object. Allowed keys: priority (1-10, lower runs sooner; default 5) and group (worker group, matches `cake queue worker --group=...`).'),
+					'help' => __d('queue_scheduler', 'Optional JSON object. Allowed keys: priority (1-10, lower runs sooner; default 5) and group (worker group, matches `cake queue worker --group=...`).'),
 				]) ?>
 			</div>
 			<div class="row">
@@ -75,7 +75,7 @@
 				</div>
 			</div>
 			<div class="mt-3">
-				<?= $this->Form->button('<i class="fas fa-save me-1"></i>' . __('Save'), ['class' => 'btn btn-primary', 'escapeTitle' => false]) ?>
+				<?= $this->Form->button('<i class="fas fa-save me-1"></i>' . __d('queue_scheduler', 'Save'), ['class' => 'btn btn-primary', 'escapeTitle' => false]) ?>
 			</div>
 			<?= $this->Form->end() ?>
 		</div>

--- a/templates/Admin/SchedulerRows/edit.php
+++ b/templates/Admin/SchedulerRows/edit.php
@@ -7,28 +7,28 @@
 <div class="scheduler-rows-edit">
 	<div class="d-flex justify-content-between align-items-center mb-4">
 		<h2 class="mb-0">
-			<i class="fas fa-edit me-2"></i><?= __('Edit Schedule') ?>
+			<i class="fas fa-edit me-2"></i><?= __d('queue_scheduler', 'Edit Schedule') ?>
 		</h2>
 		<div>
 			<?= $this->Html->link(
-				'<i class="fas fa-arrow-left me-1"></i>' . __('Back'),
+				'<i class="fas fa-arrow-left me-1"></i>' . __d('queue_scheduler', 'Back'),
 				['action' => 'index'],
 				['class' => 'btn btn-secondary me-2', 'escapeTitle' => false],
 			) ?>
 			<?= $this->Form->postButton(
-				'<i class="fas fa-trash me-1"></i>' . __('Delete'),
+				'<i class="fas fa-trash me-1"></i>' . __d('queue_scheduler', 'Delete'),
 				['action' => 'delete', $row->id],
 				[
 					'class' => 'btn btn-danger me-2',
 					'escapeTitle' => false,
 					'form' => [
 						'class' => 'd-inline',
-						'data-confirm-message' => __('Are you sure you want to delete # {0}?', $row->id),
+						'data-confirm-message' => __d('queue_scheduler', 'Are you sure you want to delete # {0}?', $row->id),
 					],
 				],
 			) ?>
 			<?= $this->Html->link(
-				'<i class="fas fa-clock me-1"></i>' . __('Intervals Help'),
+				'<i class="fas fa-clock me-1"></i>' . __d('queue_scheduler', 'Intervals Help'),
 				['controller' => 'QueueScheduler', 'action' => 'intervals'],
 				['class' => 'btn btn-outline-secondary', 'escapeTitle' => false],
 			) ?>
@@ -37,7 +37,7 @@
 
 	<div class="card">
 		<div class="card-header">
-			<i class="fas fa-cog me-2"></i><?= __('Schedule Details') ?>
+			<i class="fas fa-cog me-2"></i><?= __d('queue_scheduler', 'Schedule Details') ?>
 		</div>
 		<div class="card-body">
 			<?php
@@ -66,9 +66,9 @@
 					'type' => 'textarea',
 					'rows' => 3,
 					'class' => 'form-control',
-					'label' => __('Job Config (JSON)'),
+					'label' => __d('queue_scheduler', 'Job Config (JSON)'),
 					'placeholder' => '{"priority": 5, "group": "batch"}',
-					'help' => __('Optional JSON object. Allowed keys: priority (1-10, lower runs sooner; default 5) and group (worker group, matches `cake queue worker --group=...`).'),
+					'help' => __d('queue_scheduler', 'Optional JSON object. Allowed keys: priority (1-10, lower runs sooner; default 5) and group (worker group, matches `cake queue worker --group=...`).'),
 				]) ?>
 			</div>
 			<div class="row">
@@ -83,7 +83,7 @@
 				</div>
 			</div>
 			<div class="mt-3">
-				<?= $this->Form->button('<i class="fas fa-save me-1"></i>' . __('Save'), ['class' => 'btn btn-primary', 'escapeTitle' => false]) ?>
+				<?= $this->Form->button('<i class="fas fa-save me-1"></i>' . __d('queue_scheduler', 'Save'), ['class' => 'btn btn-primary', 'escapeTitle' => false]) ?>
 			</div>
 			<?= $this->Form->end() ?>
 		</div>

--- a/templates/Admin/SchedulerRows/index.php
+++ b/templates/Admin/SchedulerRows/index.php
@@ -7,11 +7,11 @@
 <div class="scheduler-rows-index">
 	<div class="d-flex justify-content-between align-items-center mb-4">
 		<h2 class="mb-0">
-			<i class="fas fa-list me-2"></i><?= __('All Schedules') ?>
+			<i class="fas fa-list me-2"></i><?= __d('queue_scheduler', 'All Schedules') ?>
 		</h2>
 		<div>
 			<?= $this->Html->link(
-				'<i class="fas fa-plus me-1"></i>' . __('New Schedule'),
+				'<i class="fas fa-plus me-1"></i>' . __d('queue_scheduler', 'New Schedule'),
 				['action' => 'add'],
 				['class' => 'btn btn-primary', 'escapeTitle' => false],
 			) ?>
@@ -31,7 +31,7 @@
 							<th><?= $this->Paginator->sort('enabled') ?></th>
 							<th><?= $this->Paginator->sort('created', null, ['direction' => 'desc']) ?></th>
 							<th><?= $this->Paginator->sort('modified', null, ['direction' => 'desc']) ?></th>
-							<th class="actions text-end"><?= __('Actions') ?></th>
+							<th class="actions text-end"><?= __d('queue_scheduler', 'Actions') ?></th>
 						</tr>
 					</thead>
 					<tbody>
@@ -69,12 +69,12 @@
 								<td>
 									<?= $this->element('QueueScheduler.yes_no', ['value' => $row->enabled]) ?>
 									<?php if ($row->enabled && $row->type === $row::TYPE_SHELL_COMMAND && !\Cake\Core\Configure::read('QueueScheduler.allowRaw')) { ?>
-										<span class="text-warning" title="<?= __('Raw commands are currently configured to be not runnable on non-debug system for security reasons.') ?>">
+										<span class="text-warning" title="<?= __d('queue_scheduler', 'Raw commands are currently configured to be not runnable on non-debug system for security reasons.') ?>">
 											<i class="fas fa-exclamation-triangle"></i>
 										</span>
 									<?php } elseif (!$row->enabled && !($row->type === $row::TYPE_SHELL_COMMAND && !\Cake\Core\Configure::read('QueueScheduler.allowRaw'))) { ?>
 										<?= $this->Form->postButton(
-											'<i class="fas fa-check me-1"></i>' . __('Enable'),
+											'<i class="fas fa-check me-1"></i>' . __d('queue_scheduler', 'Enable'),
 											['action' => 'edit', $row->id],
 											[
 												'data' => ['enabled' => 1],
@@ -82,7 +82,7 @@
 												'class' => 'btn btn-sm btn-success',
 												'form' => [
 													'class' => 'd-inline',
-													'data-confirm-message' => __('Sure to enable?'),
+													'data-confirm-message' => __d('queue_scheduler', 'Sure to enable?'),
 												],
 											],
 										) ?>
@@ -90,7 +90,7 @@
 
 									<?php if ($row->last_run) { ?>
 										<div>
-											<small class="text-muted"><?= __('Last Run') ?>:
+											<small class="text-muted"><?= __d('queue_scheduler', 'Last Run') ?>:
 												<?php if ($row->last_queued_job_id) { ?>
 													<?= $this->Html->link(
 														$this->Time->nice($row->last_run),
@@ -108,9 +108,9 @@
 									?>
 									<?php if ($nextRun) { ?>
 										<?php if (!$row->enabled) { ?>
-											<div><small class="next-run-canceled"><?= __('Next Run') ?>: <?= $this->Time->nice($nextRun) ?></small></div>
+											<div><small class="next-run-canceled"><?= __d('queue_scheduler', 'Next Run') ?>: <?= $this->Time->nice($nextRun) ?></small></div>
 										<?php } else { ?>
-											<div><small class="text-muted"><?= __('Next Run') ?>: <?= $this->Time->nice($nextRun) ?></small></div>
+											<div><small class="text-muted"><?= __d('queue_scheduler', 'Next Run') ?>: <?= $this->Time->nice($nextRun) ?></small></div>
 										<?php } ?>
 									<?php } ?>
 								</td>
@@ -120,12 +120,12 @@
 									<?= $this->Html->link(
 										'<i class="fas fa-eye"></i>',
 										['action' => 'view', $row->id],
-										['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-secondary me-1', 'title' => __('View')],
+										['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-secondary me-1', 'title' => __d('queue_scheduler', 'View')],
 									) ?>
 									<?= $this->Html->link(
 										'<i class="fas fa-edit"></i>',
 										['action' => 'edit', $row->id],
-										['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-secondary me-1', 'title' => __('Edit')],
+										['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-secondary me-1', 'title' => __d('queue_scheduler', 'Edit')],
 									) ?>
 									<?= $this->Form->postButton(
 										'<i class="fas fa-play-circle"></i>',
@@ -133,10 +133,10 @@
 										[
 											'escapeTitle' => false,
 											'class' => 'btn btn-sm btn-outline-success me-1',
-											'title' => __('Run manually now'),
+											'title' => __d('queue_scheduler', 'Run manually now'),
 											'form' => [
 												'class' => 'd-inline',
-												'data-confirm-message' => __('Sure to run it now?'),
+												'data-confirm-message' => __d('queue_scheduler', 'Sure to run it now?'),
 											],
 										],
 									) ?>
@@ -146,10 +146,10 @@
 										[
 											'escapeTitle' => false,
 											'class' => 'btn btn-sm btn-outline-danger',
-											'title' => __('Delete'),
+											'title' => __d('queue_scheduler', 'Delete'),
 											'form' => [
 												'class' => 'd-inline',
-												'data-confirm-message' => __('Are you sure you want to delete # {0}?', $row->id),
+												'data-confirm-message' => __d('queue_scheduler', 'Are you sure you want to delete # {0}?', $row->id),
 											],
 										],
 									) ?>

--- a/templates/Admin/SchedulerRows/view.php
+++ b/templates/Admin/SchedulerRows/view.php
@@ -16,31 +16,31 @@ $frequencyDescription = $row->getFrequencyDescription();
 		</h2>
 		<div>
 			<?= $this->Html->link(
-				'<i class="fas fa-edit me-1"></i>' . __('Edit'),
+				'<i class="fas fa-edit me-1"></i>' . __d('queue_scheduler', 'Edit'),
 				['action' => 'edit', $row->id],
 				['class' => 'btn btn-primary me-2', 'escapeTitle' => false],
 			) ?>
 			<?= $this->Form->postButton(
-				'<i class="fas fa-play-circle me-1"></i>' . __('Run Now'),
+				'<i class="fas fa-play-circle me-1"></i>' . __d('queue_scheduler', 'Run Now'),
 				['action' => 'run', $row->id],
 				[
 					'class' => 'btn btn-success me-2',
 					'escapeTitle' => false,
 					'form' => [
 						'class' => 'd-inline js-scheduler-run-form',
-						'data-confirm-message' => __('Are you sure you want to run this now?'),
+						'data-confirm-message' => __d('queue_scheduler', 'Are you sure you want to run this now?'),
 					],
 				],
 			) ?>
 			<?= $this->Form->postButton(
-				'<i class="fas fa-trash me-1"></i>' . __('Delete'),
+				'<i class="fas fa-trash me-1"></i>' . __d('queue_scheduler', 'Delete'),
 				['action' => 'delete', $row->id],
 				[
 					'class' => 'btn btn-danger',
 					'escapeTitle' => false,
 					'form' => [
 						'class' => 'd-inline',
-						'data-confirm-message' => __('Are you sure you want to delete # {0}?', $row->id),
+						'data-confirm-message' => __d('queue_scheduler', 'Are you sure you want to delete # {0}?', $row->id),
 					],
 				],
 			) ?>
@@ -51,28 +51,28 @@ $frequencyDescription = $row->getFrequencyDescription();
 		<div class="col-lg-6 mb-4">
 			<div class="card h-100">
 				<div class="card-header">
-					<i class="fas fa-info-circle me-2"></i><?= __('Schedule Details') ?>
+					<i class="fas fa-info-circle me-2"></i><?= __d('queue_scheduler', 'Schedule Details') ?>
 				</div>
 				<div class="card-body">
 					<table class="table table-striped mb-0">
 						<tr>
-							<th class="scheduler-col-w-40"><?= __('Type') ?></th>
+							<th class="scheduler-col-w-40"><?= __d('queue_scheduler', 'Type') ?></th>
 							<td><?= $row::types($row->type) ?></td>
 						</tr>
 						<?php if ($row->param) { ?>
 							<tr>
-								<th><?= __('Config') ?></th>
+								<th><?= __d('queue_scheduler', 'Config') ?></th>
 								<td><pre class="mb-0"><?= h(json_encode(json_decode($row->param, true), JSON_PRETTY_PRINT)) ?></pre></td>
 							</tr>
 						<?php } ?>
 						<?php if ($row->job_config) { ?>
 							<tr>
-								<th><?= __('Job Config') ?></th>
+								<th><?= __d('queue_scheduler', 'Job Config') ?></th>
 								<td><pre class="mb-0"><?= h(json_encode($row->job_config, JSON_PRETTY_PRINT)) ?></pre></td>
 							</tr>
 						<?php } ?>
 						<tr>
-							<th><?= __('Frequency') ?></th>
+							<th><?= __d('queue_scheduler', 'Frequency') ?></th>
 							<td>
 								<code<?= $frequencyDescription ? ' title="' . h($frequencyDescription) . '"' : '' ?>><?= h($row->frequency) ?></code>
 								<?php if ($frequencyDescription) { ?>
@@ -81,13 +81,13 @@ $frequencyDescription = $row->getFrequencyDescription();
 							</td>
 						</tr>
 						<tr>
-							<th><?= __('Enabled') ?></th>
+							<th><?= __d('queue_scheduler', 'Enabled') ?></th>
 							<td>
 								<?= $this->element('QueueScheduler.yes_no', ['value' => $row->enabled]) ?>
-								<?= $row->enabled ? __('Yes') : __('No') ?>
+								<?= $row->enabled ? __d('queue_scheduler', 'Yes') : __d('queue_scheduler', 'No') ?>
 								<?php if (!$row->enabled) { ?>
 									<?= $this->Form->postButton(
-										'<i class="fas fa-check me-1"></i>' . __('Enable'),
+										'<i class="fas fa-check me-1"></i>' . __d('queue_scheduler', 'Enable'),
 										['action' => 'edit', $row->id],
 										[
 											'data' => ['enabled' => 1],
@@ -95,7 +95,7 @@ $frequencyDescription = $row->getFrequencyDescription();
 											'class' => 'btn btn-sm btn-success ms-2',
 											'form' => [
 												'class' => 'd-inline',
-												'data-confirm-message' => __('Sure to enable?'),
+												'data-confirm-message' => __d('queue_scheduler', 'Sure to enable?'),
 											],
 										],
 									) ?>
@@ -103,10 +103,10 @@ $frequencyDescription = $row->getFrequencyDescription();
 							</td>
 						</tr>
 						<tr>
-							<th><?= __('Allow Concurrent') ?></th>
+							<th><?= __d('queue_scheduler', 'Allow Concurrent') ?></th>
 							<td>
 								<?= $this->element('QueueScheduler.yes_no', ['value' => $row->allow_concurrent]) ?>
-								<?= $row->allow_concurrent ? __('Yes') : __('No') ?>
+								<?= $row->allow_concurrent ? __d('queue_scheduler', 'Yes') : __d('queue_scheduler', 'No') ?>
 							</td>
 						</tr>
 					</table>
@@ -117,16 +117,16 @@ $frequencyDescription = $row->getFrequencyDescription();
 		<div class="col-lg-6 mb-4">
 			<div class="card h-100">
 				<div class="card-header">
-					<i class="fas fa-clock me-2"></i><?= __('Timing Information') ?>
+					<i class="fas fa-clock me-2"></i><?= __d('queue_scheduler', 'Timing Information') ?>
 				</div>
 				<div class="card-body">
 					<table class="table table-striped mb-0">
 						<tr>
-							<th class="scheduler-col-w-40"><?= __('Last Run') ?></th>
+							<th class="scheduler-col-w-40"><?= __d('queue_scheduler', 'Last Run') ?></th>
 							<td>
 								<?php $lastJob = $row->last_queued_job; ?>
 								<?php if (!$row->last_run) { ?>
-									<span class="text-muted"><?= __('Never') ?></span>
+									<span class="text-muted"><?= __d('queue_scheduler', 'Never') ?></span>
 								<?php } else { ?>
 									<?= $this->Scheduler->runStatusIcon($lastJob) ?>
 									<?php if ($row->last_queued_job_id) { ?>
@@ -159,25 +159,25 @@ $frequencyDescription = $row->getFrequencyDescription();
 						?>
 						<?php if ($nextRun) { ?>
 							<tr>
-								<th><?= __('Next Run') ?></th>
+								<th><?= __d('queue_scheduler', 'Next Run') ?></th>
 								<td>
 									<?= $this->Time->nice($nextRun) ?>
 									<?php if (!$row->enabled) { ?>
-										<span class="badge bg-secondary ms-1"><?= __('Disabled — won\'t run') ?></span>
+										<span class="badge bg-secondary ms-1"><?= __d('queue_scheduler', 'Disabled — won\'t run') ?></span>
 									<?php } else { ?>
 										<div class="small <?= $nextRunOverdue ? 'text-danger fw-semibold' : 'text-muted' ?>">
-											<?= $grosslyOverdue ? __('overdue') : h($this->Time->timeAgoInWords($nextRun)) ?>
+											<?= $grosslyOverdue ? __d('queue_scheduler', 'overdue') : h($this->Time->timeAgoInWords($nextRun)) ?>
 										</div>
 									<?php } ?>
 								</td>
 							</tr>
 						<?php } ?>
 						<tr>
-							<th><?= __('Created') ?></th>
+							<th><?= __d('queue_scheduler', 'Created') ?></th>
 							<td><?= $this->Time->nice($row->created) ?></td>
 						</tr>
 						<tr>
-							<th><?= __('Modified') ?></th>
+							<th><?= __d('queue_scheduler', 'Modified') ?></th>
 							<td><?= $this->Time->nice($row->modified) ?></td>
 						</tr>
 					</table>
@@ -188,7 +188,7 @@ $frequencyDescription = $row->getFrequencyDescription();
 
 	<div class="card mb-4">
 		<div class="card-header">
-			<i class="fas fa-code me-2"></i><?= __('Content') ?>
+			<i class="fas fa-code me-2"></i><?= __d('queue_scheduler', 'Content') ?>
 		</div>
 		<div class="card-body">
 			<pre class="mb-0"><?= h($row->content) ?></pre>
@@ -198,33 +198,33 @@ $frequencyDescription = $row->getFrequencyDescription();
 	<?php if ($jobStats && $jobStats['total_runs']) { ?>
 		<div class="card mb-4">
 			<div class="card-header">
-				<i class="fas fa-chart-bar me-2"></i><?= __('Job Statistics') ?>
+				<i class="fas fa-chart-bar me-2"></i><?= __d('queue_scheduler', 'Job Statistics') ?>
 			</div>
 			<div class="card-body">
 				<div class="row">
 					<div class="col-md-3 mb-3 mb-md-0">
 						<div class="text-center">
 							<div class="h3 mb-0"><?= $jobStats['total_runs'] ?></div>
-							<small class="text-muted"><?= __('Total Runs') ?></small>
+							<small class="text-muted"><?= __d('queue_scheduler', 'Total Runs') ?></small>
 						</div>
 					</div>
 					<div class="col-md-3 mb-3 mb-md-0">
 						<div class="text-center">
 							<div class="h3 mb-0 text-success"><?= $jobStats['completed_runs'] ?: 0 ?></div>
-							<small class="text-muted"><?= __('Completed') ?></small>
+							<small class="text-muted"><?= __d('queue_scheduler', 'Completed') ?></small>
 						</div>
 					</div>
 					<div class="col-md-3 mb-3 mb-md-0">
 						<div class="text-center">
 							<div class="h3 mb-0 text-danger"><?= $jobStats['failed_runs'] ?: 0 ?></div>
-							<small class="text-muted"><?= __('Failed') ?></small>
+							<small class="text-muted"><?= __d('queue_scheduler', 'Failed') ?></small>
 						</div>
 					</div>
 					<?php if ($jobStats['avg_duration'] !== null) { ?>
 						<div class="col-md-3">
 							<div class="text-center">
 								<div class="h3 mb-0"><?= $this->Number->precision($jobStats['avg_duration'], 1) ?>s</div>
-								<small class="text-muted"><?= __('Avg Duration') ?></small>
+								<small class="text-muted"><?= __d('queue_scheduler', 'Avg Duration') ?></small>
 								<div class="small text-muted"><?= $jobStats['min_duration'] ?>s - <?= $jobStats['max_duration'] ?>s</div>
 							</div>
 						</div>
@@ -236,10 +236,10 @@ $frequencyDescription = $row->getFrequencyDescription();
 
 	<div class="card mb-4">
 		<div class="card-header d-flex justify-content-between align-items-center">
-			<span><i class="fas fa-history me-2"></i><?= __('Recent Executions') ?></span>
+			<span><i class="fas fa-history me-2"></i><?= __d('queue_scheduler', 'Recent Executions') ?></span>
 			<?php if ($recentJobs) { ?>
 				<?= $this->Html->link(
-					__('View All in Queue'),
+					__d('queue_scheduler', 'View All in Queue'),
 					['plugin' => 'Queue', 'controller' => 'QueuedJobs', 'action' => 'index', '?' => ['search' => $row->job_reference]],
 					['class' => 'btn btn-sm btn-outline-secondary'],
 				) ?>
@@ -247,7 +247,7 @@ $frequencyDescription = $row->getFrequencyDescription();
 		</div>
 		<?php if (!$recentJobs) { ?>
 			<div class="card-body text-center text-muted py-4">
-				<?= __('No runs recorded yet.') ?>
+				<?= __d('queue_scheduler', 'No runs recorded yet.') ?>
 			</div>
 		<?php } else { ?>
 			<div class="card-body p-0">
@@ -255,10 +255,10 @@ $frequencyDescription = $row->getFrequencyDescription();
 					<table class="table table-hover mb-0">
 						<thead>
 							<tr>
-								<th><?= __('Created') ?></th>
-								<th><?= __('Status') ?></th>
-								<th><?= __('Duration') ?></th>
-								<th><?= __('Output') ?></th>
+								<th><?= __d('queue_scheduler', 'Created') ?></th>
+								<th><?= __d('queue_scheduler', 'Status') ?></th>
+								<th><?= __d('queue_scheduler', 'Duration') ?></th>
+								<th><?= __d('queue_scheduler', 'Output') ?></th>
 							</tr>
 						</thead>
 						<tbody>
@@ -274,14 +274,14 @@ $frequencyDescription = $row->getFrequencyDescription();
 									<td>
 										<?php if ($job->completed) { ?>
 											<?php if ($job->failure_message) { ?>
-												<span class="badge bg-danger"><?= __('Failed') ?></span>
+												<span class="badge bg-danger"><?= __d('queue_scheduler', 'Failed') ?></span>
 											<?php } else { ?>
-												<span class="badge bg-success"><?= __('Completed') ?></span>
+												<span class="badge bg-success"><?= __d('queue_scheduler', 'Completed') ?></span>
 											<?php } ?>
 										<?php } elseif ($job->fetched) { ?>
-											<span class="badge bg-info"><?= __('Running') ?></span>
+											<span class="badge bg-info"><?= __d('queue_scheduler', 'Running') ?></span>
 										<?php } else { ?>
-											<span class="badge bg-secondary"><?= __('Queued') ?></span>
+											<span class="badge bg-secondary"><?= __d('queue_scheduler', 'Queued') ?></span>
 										<?php } ?>
 									</td>
 									<td>
@@ -289,7 +289,7 @@ $frequencyDescription = $row->getFrequencyDescription();
 											<?php $jobDurationSec = (int)$job->fetched->diffInSeconds($job->completed); ?>
 											<span class="<?= h($this->Scheduler->durationClass($jobDurationSec, $intervalSec)) ?>"><?= h($this->Scheduler->duration($jobDurationSec)) ?></span>
 										<?php } elseif ($job->fetched) { ?>
-											<span class="text-muted"><?= __('In progress...') ?></span>
+											<span class="text-muted"><?= __d('queue_scheduler', 'In progress...') ?></span>
 										<?php } else { ?>
 											-
 										<?php } ?>
@@ -298,14 +298,14 @@ $frequencyDescription = $row->getFrequencyDescription();
 										<?php if ($job->output) { ?>
 											<details>
 												<summary class="btn btn-sm btn-outline-secondary">
-													<?= __('Show output') ?> (<?= $this->Number->toReadableSize(strlen($job->output)) ?>)
+													<?= __d('queue_scheduler', 'Show output') ?> (<?= $this->Number->toReadableSize(strlen($job->output)) ?>)
 												</summary>
 												<pre class="mt-2 p-2 bg-light small"><?= h($job->output) ?></pre>
 											</details>
 										<?php } elseif ($job->failure_message) { ?>
 											<details>
 												<summary class="btn btn-sm btn-outline-danger">
-													<?= __('Show error') ?>
+													<?= __d('queue_scheduler', 'Show error') ?>
 												</summary>
 												<pre class="mt-2 p-2 bg-light small text-danger"><?= h($job->failure_message) ?></pre>
 											</details>
@@ -325,10 +325,10 @@ $frequencyDescription = $row->getFrequencyDescription();
 	<?php if (class_exists('Cron\CronExpression') && $row->isCronExpression()) { ?>
 		<div class="card">
 			<div class="card-header">
-				<i class="fas fa-terminal me-2"></i><?= __('Crontab Expression') ?>
+				<i class="fas fa-terminal me-2"></i><?= __d('queue_scheduler', 'Crontab Expression') ?>
 			</div>
 			<div class="card-body">
-				<p class="text-muted"><?= __('If you want to port this into a native crontab line, copy and paste the following:') ?></p>
+				<p class="text-muted"><?= __d('queue_scheduler', 'If you want to port this into a native crontab line, copy and paste the following:') ?></p>
 				<?php
 				$expression = new \Cron\CronExpression(\QueueScheduler\Model\Entity\SchedulerRow::normalizeCronExpression($row->frequency));
 				?>

--- a/templates/element/QueueScheduler/mobile_nav.php
+++ b/templates/element/QueueScheduler/mobile_nav.php
@@ -11,38 +11,38 @@ $action = $request ? $request->getParam('action') : '';
 ?>
 <nav class="nav flex-column py-3">
 	<div class="px-3 mb-2">
-		<small class="text-white-50 text-uppercase fw-semibold"><?= __('Dashboard') ?></small>
+		<small class="text-white-50 text-uppercase fw-semibold"><?= __d('queue_scheduler', 'Dashboard') ?></small>
 	</div>
 	<a class="nav-link text-white<?= $controller === 'QueueScheduler' && $action === 'index' ? ' bg-primary rounded-0' : '' ?>" href="<?= $this->Url->build(['plugin' => 'QueueScheduler', 'prefix' => 'Admin', 'controller' => 'QueueScheduler', 'action' => 'index']) ?>">
-		<i class="fas fa-tachometer-alt me-2"></i><?= __('Overview') ?>
+		<i class="fas fa-tachometer-alt me-2"></i><?= __d('queue_scheduler', 'Overview') ?>
 	</a>
 
 	<div class="px-3 mt-3 mb-2">
-		<small class="text-white-50 text-uppercase fw-semibold"><?= __('Scheduled Jobs') ?></small>
+		<small class="text-white-50 text-uppercase fw-semibold"><?= __d('queue_scheduler', 'Scheduled Jobs') ?></small>
 	</div>
 	<a class="nav-link text-white<?= $controller === 'SchedulerRows' && $action === 'index' ? ' bg-primary rounded-0' : '' ?>" href="<?= $this->Url->build(['plugin' => 'QueueScheduler', 'prefix' => 'Admin', 'controller' => 'SchedulerRows', 'action' => 'index']) ?>">
-		<i class="fas fa-list me-2"></i><?= __('All Schedules') ?>
+		<i class="fas fa-list me-2"></i><?= __d('queue_scheduler', 'All Schedules') ?>
 	</a>
 	<a class="nav-link text-white<?= $controller === 'SchedulerRows' && $action === 'add' ? ' bg-primary rounded-0' : '' ?>" href="<?= $this->Url->build(['plugin' => 'QueueScheduler', 'prefix' => 'Admin', 'controller' => 'SchedulerRows', 'action' => 'add']) ?>">
-		<i class="fas fa-plus me-2"></i><?= __('Add Schedule') ?>
+		<i class="fas fa-plus me-2"></i><?= __d('queue_scheduler', 'Add Schedule') ?>
 	</a>
 
 	<div class="px-3 mt-3 mb-2">
-		<small class="text-white-50 text-uppercase fw-semibold"><?= __('Reference') ?></small>
+		<small class="text-white-50 text-uppercase fw-semibold"><?= __d('queue_scheduler', 'Reference') ?></small>
 	</div>
 	<a class="nav-link text-white<?= $controller === 'QueueScheduler' && $action === 'intervals' ? ' bg-primary rounded-0' : '' ?>" href="<?= $this->Url->build(['plugin' => 'QueueScheduler', 'prefix' => 'Admin', 'controller' => 'QueueScheduler', 'action' => 'intervals']) ?>">
-		<i class="fas fa-clock me-2"></i><?= __('Intervals Help') ?>
+		<i class="fas fa-clock me-2"></i><?= __d('queue_scheduler', 'Intervals Help') ?>
 	</a>
 
 	<?php if (\Cake\Core\Plugin::isLoaded('Queue')): ?>
 	<div class="px-3 mt-3 mb-2">
-		<small class="text-white-50 text-uppercase fw-semibold"><?= __('Queue Plugin') ?></small>
+		<small class="text-white-50 text-uppercase fw-semibold"><?= __d('queue_scheduler', 'Queue Plugin') ?></small>
 	</div>
 	<a class="nav-link text-white" href="<?= $this->Url->build(['plugin' => 'Queue', 'prefix' => 'Admin', 'controller' => 'Queue', 'action' => 'index']) ?>">
-		<i class="fas fa-layer-group me-2"></i><?= __('Queue Dashboard') ?>
+		<i class="fas fa-layer-group me-2"></i><?= __d('queue_scheduler', 'Queue Dashboard') ?>
 	</a>
 	<a class="nav-link text-white" href="<?= $this->Url->build(['plugin' => 'Queue', 'prefix' => 'Admin', 'controller' => 'QueuedJobs', 'action' => 'index']) ?>">
-		<i class="fas fa-tasks me-2"></i><?= __('Queued Jobs') ?>
+		<i class="fas fa-tasks me-2"></i><?= __d('queue_scheduler', 'Queued Jobs') ?>
 	</a>
 	<?php endif; ?>
 </nav>

--- a/templates/element/QueueScheduler/sidebar.php
+++ b/templates/element/QueueScheduler/sidebar.php
@@ -11,47 +11,47 @@ $action = $request ? $request->getParam('action') : '';
 ?>
 <aside class="scheduler-sidebar d-none d-lg-block">
 	<div class="nav-section">
-		<div class="nav-section-title"><?= __('Dashboard') ?></div>
+		<div class="nav-section-title"><?= __d('queue_scheduler', 'Dashboard') ?></div>
 		<nav class="nav flex-column">
 			<a class="nav-link<?= $controller === 'QueueScheduler' && $action === 'index' ? ' active' : '' ?>" href="<?= $this->Url->build(['plugin' => 'QueueScheduler', 'prefix' => 'Admin', 'controller' => 'QueueScheduler', 'action' => 'index']) ?>">
-				<i class="fas fa-tachometer-alt"></i><?= __('Overview') ?>
+				<i class="fas fa-tachometer-alt"></i><?= __d('queue_scheduler', 'Overview') ?>
 			</a>
 		</nav>
 	</div>
 
 	<div class="nav-section">
-		<div class="nav-section-title"><?= __('Scheduled Jobs') ?></div>
+		<div class="nav-section-title"><?= __d('queue_scheduler', 'Scheduled Jobs') ?></div>
 		<nav class="nav flex-column">
 			<a class="nav-link<?= $controller === 'SchedulerRows' && $action === 'index' ? ' active' : '' ?>" href="<?= $this->Url->build(['plugin' => 'QueueScheduler', 'prefix' => 'Admin', 'controller' => 'SchedulerRows', 'action' => 'index']) ?>">
-				<i class="fas fa-list"></i><?= __('All Schedules') ?>
+				<i class="fas fa-list"></i><?= __d('queue_scheduler', 'All Schedules') ?>
 			</a>
 			<a class="nav-link<?= $controller === 'SchedulerRows' && $action === 'add' ? ' active' : '' ?>" href="<?= $this->Url->build(['plugin' => 'QueueScheduler', 'prefix' => 'Admin', 'controller' => 'SchedulerRows', 'action' => 'add']) ?>">
-				<i class="fas fa-plus"></i><?= __('Add Schedule') ?>
+				<i class="fas fa-plus"></i><?= __d('queue_scheduler', 'Add Schedule') ?>
 			</a>
 		</nav>
 	</div>
 
 	<div class="nav-section">
-		<div class="nav-section-title"><?= __('Reference') ?></div>
+		<div class="nav-section-title"><?= __d('queue_scheduler', 'Reference') ?></div>
 		<nav class="nav flex-column">
 			<a class="nav-link<?= $controller === 'QueueScheduler' && $action === 'available' ? ' active' : '' ?>" href="<?= $this->Url->build(['plugin' => 'QueueScheduler', 'prefix' => 'Admin', 'controller' => 'QueueScheduler', 'action' => 'available']) ?>">
-				<i class="fas fa-list"></i><?= __('Commands & Tasks') ?>
+				<i class="fas fa-list"></i><?= __d('queue_scheduler', 'Commands & Tasks') ?>
 			</a>
 			<a class="nav-link<?= $controller === 'QueueScheduler' && $action === 'intervals' ? ' active' : '' ?>" href="<?= $this->Url->build(['plugin' => 'QueueScheduler', 'prefix' => 'Admin', 'controller' => 'QueueScheduler', 'action' => 'intervals']) ?>">
-				<i class="fas fa-clock"></i><?= __('Intervals Help') ?>
+				<i class="fas fa-clock"></i><?= __d('queue_scheduler', 'Intervals Help') ?>
 			</a>
 		</nav>
 	</div>
 
 	<?php if (\Cake\Core\Plugin::isLoaded('Queue')): ?>
 	<div class="nav-section">
-		<div class="nav-section-title"><?= __('Queue Plugin') ?></div>
+		<div class="nav-section-title"><?= __d('queue_scheduler', 'Queue Plugin') ?></div>
 		<nav class="nav flex-column">
 			<a class="nav-link" href="<?= $this->Url->build(['plugin' => 'Queue', 'prefix' => 'Admin', 'controller' => 'Queue', 'action' => 'index']) ?>">
-				<i class="fas fa-layer-group"></i><?= __('Queue Dashboard') ?>
+				<i class="fas fa-layer-group"></i><?= __d('queue_scheduler', 'Queue Dashboard') ?>
 			</a>
 			<a class="nav-link" href="<?= $this->Url->build(['plugin' => 'Queue', 'prefix' => 'Admin', 'controller' => 'QueuedJobs', 'action' => 'index']) ?>">
-				<i class="fas fa-tasks"></i><?= __('Queued Jobs') ?>
+				<i class="fas fa-tasks"></i><?= __d('queue_scheduler', 'Queued Jobs') ?>
 			</a>
 		</nav>
 	</div>

--- a/templates/element/available.php
+++ b/templates/element/available.php
@@ -10,7 +10,7 @@ $scheduler = $this->Scheduler;
 ?>
 <div class="row">
 	<div class="col-md-6 mb-3 mb-md-0">
-		<h5><i class="fas fa-terminal me-2"></i><?= __('Available Commands') ?></h5>
+		<h5><i class="fas fa-terminal me-2"></i><?= __d('queue_scheduler', 'Available Commands') ?></h5>
 		<ul class="list-unstyled">
 			<?php foreach ($scheduler->availableCommands() as $name => $command) { ?>
 				<li class="mb-2">
@@ -22,7 +22,7 @@ $scheduler = $this->Scheduler;
 	</div>
 
 	<div class="col-md-6">
-		<h5><i class="fas fa-tasks me-2"></i><?= __('Available Queue Tasks') ?></h5>
+		<h5><i class="fas fa-tasks me-2"></i><?= __d('queue_scheduler', 'Available Queue Tasks') ?></h5>
 		<ul class="list-unstyled">
 			<?php foreach ($scheduler->availableQueueTasks() as $name => $queueTask) { ?>
 				<li class="mb-2">

--- a/templates/element/pagination.php
+++ b/templates/element/pagination.php
@@ -23,7 +23,7 @@ $this->Paginator->setTemplates([
 	'current' => '<li class="page-item active"><span class="page-link">{{text}}</span></li>',
 ]);
 ?>
-<nav class="mt-3" aria-label="<?= __('Page navigation') ?>">
+<nav class="mt-3" aria-label="<?= __d('queue_scheduler', 'Page navigation') ?>">
 	<ul class="pagination justify-content-center mb-2">
 		<?= $this->Paginator->first('<i class="fas fa-angle-double-left"></i>', ['escape' => false]) ?>
 		<?= $this->Paginator->prev('<i class="fas fa-angle-left"></i>', ['escape' => false]) ?>
@@ -32,6 +32,6 @@ $this->Paginator->setTemplates([
 		<?= $this->Paginator->last('<i class="fas fa-angle-double-right"></i>', ['escape' => false]) ?>
 	</ul>
 	<p class="text-center text-muted small mb-0">
-		<?= $this->Paginator->counter(__('Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total')) ?>
+		<?= $this->Paginator->counter(__d('queue_scheduler', 'Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total')) ?>
 	</p>
 </nav>

--- a/templates/element/quick_add.php
+++ b/templates/element/quick_add.php
@@ -18,10 +18,10 @@ $tasks = $scheduler->availableQueueTasks();
 <div class="card mb-4">
 	<div class="card-body">
 		<label class="form-label" for="quick-add-search">
-			<i class="fas fa-bolt me-2"></i><?= __('Quick Add') ?>
+			<i class="fas fa-bolt me-2"></i><?= __d('queue_scheduler', 'Quick Add') ?>
 		</label>
 		<input type="text" id="quick-add-search" class="form-control form-control-lg"
-			   list="quick-add-options" placeholder="<?= __('Search commands or tasks...') ?>"
+			   list="quick-add-options" placeholder="<?= __d('queue_scheduler', 'Search commands or tasks...') ?>"
 			   autocomplete="off">
 		<datalist id="quick-add-options">
 			<?php foreach ($commands as $name => $command) { ?>
@@ -31,7 +31,7 @@ $tasks = $scheduler->availableQueueTasks();
 				<option value="<?= h($name) ?> (Task)" data-name="<?= h($name) ?>" data-type="<?= SchedulerRow::TYPE_QUEUE_TASK ?>" data-content="<?= h($task) ?>">
 			<?php } ?>
 		</datalist>
-		<div class="form-text"><?= __('Select a command or task to pre-fill the form') ?></div>
+		<div class="form-text"><?= __d('queue_scheduler', 'Select a command or task to pre-fill the form') ?></div>
 	</div>
 </div>
 <?php $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', ''); ?>

--- a/templates/layout/queue_scheduler.php
+++ b/templates/layout/queue_scheduler.php
@@ -361,7 +361,7 @@ $nonceAttr = $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '';
 					</li>
 					<?php endif; ?>
 					<li class="nav-item">
-						<span class="nav-link text-light" title="<?= __('Server Time') ?>">
+						<span class="nav-link text-light" title="<?= __d('queue_scheduler', 'Server Time') ?>">
 							<i class="far fa-clock me-1"></i>
 							<?= date('Y-m-d H:i:s') ?>
 						</span>


### PR DESCRIPTION
## Summary

- Convert 179 `__()` calls across `src/` and `templates/` to `__d('queue_scheduler', ...)` so plugin strings live in their own domain. The 4 pre-existing `__d('queue_scheduler', ...)` calls already pointed at the right domain — the rest of the plugin now matches.
- Add `resources/locales/queue_scheduler.pot` (137 unique msgids) generated via `bin/cake i18n extract` so language packs can be derived from a stable POT.

## Why

Plugin strings were landing in the host app's `default` domain. Anyone translating the host app would have ended up translating this plugin's UI under their own domain — and shipping a translated language pack with the plugin was effectively impossible.

## Verification (local)

- phpunit: 105 / 105 (1 skipped)
- phpstan: no errors
- phpcs: clean