### PR TITLE
Guard job_config column-type cast against pre-migration schema

### DIFF
--- a/src/Model/Table/SchedulerRowsTable.php
+++ b/src/Model/Table/SchedulerRowsTable.php
@@ -70,8 +70,14 @@ class SchedulerRowsTable extends Table {
 		]);
 
 		// Stored as JSON text but exposed as array in PHP — Cake handles the
-		// encode/decode round-trip transparently.
-		$this->getSchema()->setColumnType('job_config', 'json');
+		// encode/decode round-trip transparently. Guarded so that bootstrapping
+		// the table against a not-yet-migrated schema (e.g. mid-upgrade, before
+		// `migrations migrate` has run) doesn't crash; the cast attaches once
+		// the column lands.
+		$schema = $this->getSchema();
+		if ($schema->hasColumn('job_config')) {
+			$schema->setColumnType('job_config', 'json');
+		}
 	}
 
 	/**

--- a/tests/TestCase/Model/Table/SchedulerRowsTableTest.php
+++ b/tests/TestCase/Model/Table/SchedulerRowsTableTest.php
@@ -283,6 +283,40 @@ class SchedulerRowsTableTest extends TestCase {
 	}
 
 	/**
+	 * The migration must keep `job_config` shipped with the JSON column-type
+	 * cast wired up. Guards against future "remove the migration but keep the
+	 * setColumnType()" drift that would crash on fresh installs.
+	 *
+	 * @return void
+	 */
+	public function testJobConfigColumnIsCastToJson(): void {
+		$schema = $this->SchedulerRows->getSchema();
+		$this->assertTrue($schema->hasColumn('job_config'));
+		$this->assertSame('json', $schema->getColumnType('job_config'));
+	}
+
+	/**
+	 * Bootstrapping the table against a schema that doesn't yet have
+	 * `job_config` (e.g. an upgrade where `migrations migrate` hasn't run yet)
+	 * must not throw — otherwise the deploy is unrecoverable from stock state.
+	 *
+	 * @return void
+	 */
+	public function testInitializeToleratesMissingJobConfigColumn(): void {
+		$this->getTableLocator()->remove('QueueScheduler.SchedulerRowsPreMigration');
+
+		$table = $this->getTableLocator()->get('QueueScheduler.SchedulerRowsPreMigration', [
+			'className' => SchedulerRowsTable::class,
+			'schema' => [
+				'id' => ['type' => 'integer'],
+				'name' => ['type' => 'string'],
+			],
+		]);
+
+		$this->assertFalse($table->getSchema()->hasColumn('job_config'));
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testValidateContent(): void {


### PR DESCRIPTION
## Summary

`SchedulerRowsTable::initialize()` calls `setColumnType('job_config', 'json')` unconditionally. On an upgrade from 0.2.x where the table is bootstrapped via `TableRegistry` before `bin/cake migrations migrate` has had a chance to run, this throws `DatabaseException: Column job_config of table queue_scheduler_rows: The column type json can only be set if the column already exists` and the deploy can't recover.

The migration that adds the column (`20260430000000_QueueSchedulerIndexesAndJobConfig`) is shipped as of 0.3.0, so a clean run of `migrations migrate` is all that's needed — but the eager cast in `initialize()` makes the table fragile against any pre-migration schema reflection.

This guards the cast on `hasColumn('job_config')` so the boot path is safe. The JSON cast attaches once the column lands.

## Changes

- `src/Model/Table/SchedulerRowsTable.php` — wrap `setColumnType()` in `hasColumn()` check.
- `tests/TestCase/Model/Table/SchedulerRowsTableTest.php`:
  - `testJobConfigColumnIsCastToJson` — asserts the column ships and is typed `json` (catches future "remove migration but keep cast" drift).
  - `testInitializeToleratesMissingJobConfigColumn` — boots a `SchedulerRowsTable` against a synthetic schema without `job_config` and asserts no exception.

Closes #33
