### PR TITLE
Tokenize shell-command rows into executable and arguments on dispatch

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -149,6 +149,26 @@ sh /some/shell.sh
 
 This type does not need the param textarea as all args are directly passed along the command here.
 
+The content is split on whitespace before dispatch: the first token becomes the
+executable (matched against `Queue.executeAllowedCommands` verbatim) and each
+remaining token is forwarded as its own argument (each `escapeshellarg`'d
+individually by `Queue.Execute`). With debug off, the production allow-list
+therefore lists executables — e.g. `bin/cake`, `/usr/bin/php`, `sh` — not full
+command lines:
+
+```php
+'Queue' => [
+    'executeAllowedCommands' => [
+        'bin/cake',
+        'sh',
+    ],
+],
+```
+
+Quote-aware tokenization is intentionally not performed; if you need a
+composite shell line (pipes, redirection, embedded quoting) put it in a
+wrapper script and schedule the script path instead.
+
 ### Job Config (queue routing & priority)
 
 The optional **Job Config** field accepts a JSON object that is merged into

--- a/src/Model/Entity/SchedulerRow.php
+++ b/src/Model/Entity/SchedulerRow.php
@@ -318,7 +318,18 @@ class SchedulerRow extends Entity {
 			return $param;
 		}
 		if ($this->type === static::TYPE_SHELL_COMMAND) {
-			return ['command' => $this->content];
+			// Split on whitespace so the executable lands in `command` and each
+			// argument lands as its own entry in `params`. ExecuteTask matches
+			// `command` against `Queue.executeAllowedCommands` verbatim and
+			// `escapeshellarg()`s each `params` entry individually, so the
+			// allow-list can gate by executable (e.g. `bin/cake`) instead of
+			// requiring an entry per argument permutation. Quote-aware
+			// tokenization is intentionally not done — admins who need a
+			// composite shell line should call a wrapper script.
+			$tokens = preg_split('/\s+/', trim($this->content)) ?: [];
+			$command = (string)array_shift($tokens);
+
+			return ['command' => $command, 'params' => $tokens];
 		}
 		if ($this->type === static::TYPE_CAKE_COMMAND) {
 			return ['class' => $this->content, 'args' => $param];

--- a/src/Model/Entity/SchedulerRow.php
+++ b/src/Model/Entity/SchedulerRow.php
@@ -326,7 +326,7 @@ class SchedulerRow extends Entity {
 			// requiring an entry per argument permutation. Quote-aware
 			// tokenization is intentionally not done — admins who need a
 			// composite shell line should call a wrapper script.
-			$tokens = preg_split('/\s+/', trim($this->content)) ?: [];
+			$tokens = preg_split('/\s+/', trim($this->content), -1, PREG_SPLIT_NO_EMPTY) ?: [];
 			$command = (string)array_shift($tokens);
 
 			return ['command' => $command, 'params' => $tokens];

--- a/tests/TestCase/Model/Entity/RowTest.php
+++ b/tests/TestCase/Model/Entity/RowTest.php
@@ -30,7 +30,7 @@ class RowTest extends TestCase {
 		$row->type = $row::TYPE_SHELL_COMMAND;
 
 		$this->assertSame('Queue.Execute', $row->job_task);
-		$this->assertEquals(['command' => 'uname'], $row->job_data);
+		$this->assertSame(['command' => 'uname', 'params' => []], $row->job_data);
 	}
 
 	/**

--- a/tests/TestCase/Model/Entity/SchedulerRowTest.php
+++ b/tests/TestCase/Model/Entity/SchedulerRowTest.php
@@ -435,4 +435,66 @@ class SchedulerRowTest extends TestCase {
 		$this->assertNull($row->calculateNextRun());
 	}
 
+	// -----------------------------------------------------------------------
+	// _getJobData() — shell command tokenization
+	// -----------------------------------------------------------------------
+
+	/**
+	 * A shell command with arguments splits on whitespace so the executable
+	 * is the `command` field and each arg is its own `params` entry. This
+	 * lets `Queue.executeAllowedCommands` gate by executable instead of
+	 * requiring a literal full-string match per argument permutation.
+	 *
+	 * @return void
+	 */
+	public function testJobDataSplitsShellCommandIntoExecutableAndArgs(): void {
+		$row = new SchedulerRow([
+			'type' => SchedulerRow::TYPE_SHELL_COMMAND,
+			'content' => 'bin/cake user_notification -q -m 4 -l 100',
+		]);
+
+		$this->assertSame(
+			['command' => 'bin/cake', 'params' => ['user_notification', '-q', '-m', '4', '-l', '100']],
+			$row->job_data,
+		);
+	}
+
+	/**
+	 * A bare executable (no arguments) yields an empty `params` array, not
+	 * a missing key — `ExecuteTask::run()` already tolerates an empty list,
+	 * but a consistent shape is easier to reason about.
+	 *
+	 * @return void
+	 */
+	public function testJobDataForBareShellCommandHasEmptyParams(): void {
+		$row = new SchedulerRow([
+			'type' => SchedulerRow::TYPE_SHELL_COMMAND,
+			'content' => '/usr/local/bin/run-something',
+		]);
+
+		$this->assertSame(
+			['command' => '/usr/local/bin/run-something', 'params' => []],
+			$row->job_data,
+		);
+	}
+
+	/**
+	 * Runs of whitespace and surrounding padding collapse — admins may paste
+	 * a command with stray indentation and the splitter must not produce
+	 * empty `params` entries that would later be `escapeshellarg`'d as `''`.
+	 *
+	 * @return void
+	 */
+	public function testJobDataCollapsesWhitespaceInShellCommand(): void {
+		$row = new SchedulerRow([
+			'type' => SchedulerRow::TYPE_SHELL_COMMAND,
+			'content' => "  bin/cake   foo\t-x  ",
+		]);
+
+		$this->assertSame(
+			['command' => 'bin/cake', 'params' => ['foo', '-x']],
+			$row->job_data,
+		);
+	}
+
 }

--- a/tests/TestCase/Model/Entity/SchedulerRowTest.php
+++ b/tests/TestCase/Model/Entity/SchedulerRowTest.php
@@ -497,4 +497,23 @@ class SchedulerRowTest extends TestCase {
 		);
 	}
 
+	/**
+	 * Defense-in-depth: empty/whitespace-only content (which `validateContent`
+	 * already rejects at save time but could still arrive via direct SQL or a
+	 * marshalling path that bypasses validation) must not produce phantom
+	 * empty-string entries in `params`. The dispatch will fail downstream on
+	 * an empty `command`, but at least the shape is well-formed and the
+	 * failure surface stays narrow.
+	 *
+	 * @return void
+	 */
+	public function testJobDataRejectsPhantomEmptyTokensForEmptyShellContent(): void {
+		$row = new SchedulerRow([
+			'type' => SchedulerRow::TYPE_SHELL_COMMAND,
+			'content' => '   ',
+		]);
+
+		$this->assertSame(['command' => '', 'params' => []], $row->job_data);
+	}
+
 }


### PR DESCRIPTION
## Summary

When a `Shell Command` scheduler row is dispatched, the entity now splits the `content` field on whitespace before passing it to `Queue.Execute`: the first token becomes `command`, each remaining token becomes its own `params` entry. Previously the entire `content` string was assigned to `command` verbatim.

This aligns the dispatch shape with `Queue.Execute`'s contract:

- `Queue.executeAllowedCommands` (the queue plugin's security gate when `debug` is off) compares against `command` verbatim. With the old shape, the production allow-list had to contain the full command line including every argument — forcing one entry per argument permutation, and any param change broke the match. With the split, the allow-list lists executables (`'bin/cake'`, `'sh'`, ...) — matching what the queue plugin's own `app.example.php` documents.
- `escapeshellarg()` is now applied per token rather than once over the entire tail. Args containing whitespace can no longer slip extra tokens past quoting.

The split is whitespace-only — no quote-aware tokenization. Composite shell lines (pipes, redirection, embedded quoting) should be wrapped in a script and the script path scheduled instead. Documented in the README.

`Cake Command` and `Queue Task` types are unchanged.