### PR TITLE
Normalize empty JSON-collection params; polish param docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -104,6 +104,18 @@ The command exits with a non-zero status if any row threw while being
 scheduled (a row being held back because a previous run is still queued
 is **not** counted as a failure).
 
+### Row types at a glance
+
+The three row types differ in what goes in **Content** and **Param**:
+
+| Type | Content | Param | Param shape |
+|---|---|---|---|
+| Queue Task | `Plugin.Name` or FQCN ending in `Task` | optional payload | JSON object `{...}` |
+| Cake Command | `Plugin.Name` or FQCN ending in `Command` | optional argv | JSON array `[...]` |
+| Shell Command | full command line (e.g. `bin/cake foo --bar`) | **must be empty** | — |
+
+**Empty param means "no payload / no args"** for Queue Task and Cake Command — leave the field blank. The literals `[]` and `{}` (and whitespace variants like `[ ]` / `{\n}`) are accepted as a typo-friendly synonym for "blank" and normalized to an empty string at save time, so they do not trip the validators that otherwise reject empty collections.
+
 ### Scheduling Queue Tasks
 
 You can directly add Queue Tasks using `Plugin.Name` syntax or FQCN.
@@ -114,7 +126,7 @@ Queue\Queue\Task\ExampleTask
 ```
 
 If you need to pass some payload data, you can use the param textarea for this using JSON:
-```
+```json
 {
     "dryRun": true,
     "id": 123,
@@ -131,14 +143,16 @@ MyPlugin.MyName
 Cake\Command\SchemacacheBuildCommand
 ```
 
-If you need to pass additional args, you can use the param textarea for this using JSON:
-```
+If you need to pass additional args, you can use the param textarea for this using JSON. Each entry is one argv token — the array is forwarded straight to `$command->run($args, $io)`, so use one entry per token rather than embedding shell-style quoting inside a single string:
+```json
 [
     "-v",
     "--dry-run",
-    "--some-option \"Some value\"",
+    "--some-option=Some value"
 ]
 ```
+
+If the command takes no arguments, leave the field blank rather than typing `[]`.
 
 ### Scheduling Shell Commands
 For security reasons executing raw shell commands is only enabled by default for debug mode.

--- a/src/Model/Table/SchedulerRowsTable.php
+++ b/src/Model/Table/SchedulerRowsTable.php
@@ -292,6 +292,35 @@ class SchedulerRowsTable extends Table {
 	public function beforeMarshal(EventInterface $event, ArrayObject $data, ArrayObject $options): void {
 		$this->adjustQueueTask($data);
 		$this->adjustCakeCommand($data);
+		$this->adjustParam($data);
+	}
+
+	/**
+	 * Collapse "no payload" JSON literals to an empty string before validation.
+	 *
+	 * Both `validateQueueTaskParam` and `validateCakeCommandParam` reject `{}`
+	 * and `[]` via `!empty($decoded)`, so a user who explicitly types the empty
+	 * literal — meaning "no args / no payload" — would otherwise hit a
+	 * confusing validation error. The field already accepts an empty string
+	 * for that intent (see `allowEmptyString('param')`), so normalize the
+	 * literal to the same shape. Whitespace-only variants like `[ ]`, `{\n}`
+	 * are caught via `json_decode` rather than a string compare.
+	 *
+	 * @param \ArrayObject $data
+	 * @return void
+	 */
+	protected function adjustParam(ArrayObject $data): void {
+		if (!isset($data['param']) || !is_string($data['param'])) {
+			return;
+		}
+		if (trim($data['param']) === '') {
+			return;
+		}
+
+		$decoded = json_decode($data['param'], true);
+		if (is_array($decoded) && !$decoded) {
+			$data['param'] = '';
+		}
 	}
 
 	/**

--- a/tests/TestCase/Model/Table/SchedulerRowsTableTest.php
+++ b/tests/TestCase/Model/Table/SchedulerRowsTableTest.php
@@ -423,4 +423,85 @@ class SchedulerRowsTableTest extends TestCase {
 		}
 	}
 
+	/**
+	 * `[]` typed for a Cake Command param means "no args" — the field already
+	 * accepts an empty string for that intent, so normalize the literal at
+	 * marshal time instead of bouncing the user with a validation error.
+	 *
+	 * @return void
+	 */
+	public function testEmptyJsonArrayParamIsNormalizedToEmptyStringForCakeCommand(): void {
+		$data = [
+			'name' => 'cake cmd',
+			'content' => CacheClearCommand::class,
+			'type' => SchedulerRow::TYPE_CAKE_COMMAND,
+			'frequency' => '@daily',
+			'param' => '[]',
+		];
+		$row = $this->SchedulerRows->newEntity($data);
+
+		$this->assertSame('', $row->param);
+		$this->assertSame([], $row->getError('param'));
+	}
+
+	/**
+	 * Same normalization for Queue Task: `{}` collapses to empty string so the
+	 * row saves with "no payload" rather than failing on the empty-object
+	 * literal.
+	 *
+	 * @return void
+	 */
+	public function testEmptyJsonObjectParamIsNormalizedToEmptyStringForQueueTask(): void {
+		$data = [
+			'name' => 'queue task',
+			'content' => ExampleTask::class,
+			'type' => SchedulerRow::TYPE_QUEUE_TASK,
+			'frequency' => '@daily',
+			'param' => '{}',
+		];
+		$row = $this->SchedulerRows->newEntity($data);
+
+		$this->assertSame('', $row->param);
+		$this->assertSame([], $row->getError('param'));
+	}
+
+	/**
+	 * Whitespace-padded variants (`[ ]`, `{\n}`) decode to empty arrays too —
+	 * a string compare against the literal would miss these, but the
+	 * `json_decode`-based check catches them.
+	 *
+	 * @return void
+	 */
+	public function testWhitespacePaddedEmptyJsonParamIsNormalized(): void {
+		$data = [
+			'name' => 'cake cmd',
+			'content' => CacheClearCommand::class,
+			'type' => SchedulerRow::TYPE_CAKE_COMMAND,
+			'frequency' => '@daily',
+			'param' => "[\n  \n]",
+		];
+		$row = $this->SchedulerRows->newEntity($data);
+
+		$this->assertSame('', $row->param);
+	}
+
+	/**
+	 * Real values pass through unchanged — the normalizer only fires on
+	 * decoded-empty arrays.
+	 *
+	 * @return void
+	 */
+	public function testNonEmptyParamIsLeftAlone(): void {
+		$data = [
+			'name' => 'cake cmd',
+			'content' => CacheClearCommand::class,
+			'type' => SchedulerRow::TYPE_CAKE_COMMAND,
+			'frequency' => '@daily',
+			'param' => '["-q"]',
+		];
+		$row = $this->SchedulerRows->newEntity($data);
+
+		$this->assertSame('["-q"]', $row->param);
+	}
+
 }


### PR DESCRIPTION
## Summary

Two small ergonomics fixes for the **Param** field on Queue Task and Cake Command rows.

### 1. Auto-normalize empty-collection literals

`validateQueueTaskParam` and `validateCakeCommandParam` both reject `[]` and `{}` via `!empty($decoded)`, but the field already accepts an empty string to mean "no payload / no args" (`allowEmptyString('param')`). A user who explicitly types the empty literal therefore hits a confusing validation error for what is clearly the same intent.

`SchedulerRowsTable::beforeMarshal()` now calls a new `adjustParam()` peer that JSON-decodes the value and collapses it to an empty string when the result is an empty array. Whitespace-padded variants (`[ ]`, `{\n}`) are caught via `json_decode` rather than a string compare. Real values are left alone.

### 2. Param docs polish

- New **Row types at a glance** quick-reference table at the top of the type-specific sections so users can compare Content/Param shapes without scrolling between subsections.
- Documents the "empty allowed" rule (blank = "no payload / no args") and the new empty-collection normalization.
- Fixes the misleading Cake Command example: each array entry is one argv token forwarded straight to `Command::run($args, $io)`, so the previous `"--some-option \"Some value\""` form (with embedded shell-style quoting inside one entry) does not behave as it would on a real shell. Replaced with the `--some-option=Some value` form, which lands as a single argv token.

Shell Command rules are unchanged — Param still must be empty there (args belong with the executable in Content).