### PR TITLE
Fix isDue stale-next_run loop and racy run() compare-and-swap

### DIFF
--- a/src/Model/Entity/SchedulerRow.php
+++ b/src/Model/Entity/SchedulerRow.php
@@ -99,19 +99,27 @@ class SchedulerRow extends Entity {
 	 */
 	public function isDue(): bool {
 		$nextRun = $this->next_run;
+		$lastRun = $this->last_run;
 
 		$dateTime = new DateTime();
 		if ($nextRun) {
-			return $nextRun->timestamp <= $dateTime->timestamp;
+			// Don't trust `next_run` alone — if a previous tick already executed
+			// this row but the dispatcher crashed before advancing `next_run`,
+			// the row would re-fire on every subsequent tick. Once `last_run`
+			// has caught up to (or past) the scheduled slot, ignore the stale
+			// `next_run` and fall through to recompute from the frequency.
+			if ($lastRun === null || $lastRun->timestamp < $nextRun->timestamp) {
+				return $nextRun->timestamp <= $dateTime->timestamp;
+			}
 		}
 
 		$nextInterval = $this->calculateNextInterval();
 		if ($nextInterval) {
-			if ($this->last_run === null) {
+			if ($lastRun === null) {
 				return true;
 			}
 
-			return $this->last_run->add($nextInterval)->timestamp <= $dateTime->timestamp;
+			return $lastRun->add($nextInterval)->timestamp <= $dateTime->timestamp;
 		}
 
 		return (new CronExpression(static::normalizeCronExpression($this->frequency)))->isDue($dateTime->toDateTimeString());

--- a/src/Model/Table/SchedulerRowsTable.php
+++ b/src/Model/Table/SchedulerRowsTable.php
@@ -416,21 +416,62 @@ class SchedulerRowsTable extends Table {
 			throw new RuntimeException('Cannot add job task for ' . $row->name);
 		}
 
+		// Wrap the whole isQueued → createJob → save chain in a transaction
+		// AND guard the row update with a compare-and-swap on `last_run`. Two
+		// scheduler ticks landing within the same second on different hosts
+		// (or even the same host with parallel cron) would otherwise both
+		// observe `isQueued() === false`, both `createJob()`, and both write
+		// `last_run`. The `updateAll(..., ['id' => $row->id, 'last_run IS' => $oldLastRun])`
+		// makes the second writer a no-op: if zero rows are updated we have
+		// lost the race, so we delete the queued job we just inserted and
+		// return false. The transaction ensures the createJob → updateAll
+		// pair is atomic and rolled back together on failure.
 		$config = $row->job_config;
 		$config['reference'] = $row->job_reference;
+		$oldLastRun = $row->last_run;
 
-		/** @var \Queue\Model\Table\QueuedJobsTable $queuedJobsTable */
-		$queuedJobsTable = TableRegistry::getTableLocator()->get('Queue.QueuedJobs');
-		if (!$row->allow_concurrent && $queuedJobsTable->isQueued($row->job_reference, $row->job_task)) {
-			return false;
-		}
+		return $this->getConnection()->transactional(function () use ($row, $config, $oldLastRun): bool {
+			/** @var \Queue\Model\Table\QueuedJobsTable $queuedJobsTable */
+			$queuedJobsTable = TableRegistry::getTableLocator()->get('Queue.QueuedJobs');
+			if (!$row->allow_concurrent && $queuedJobsTable->isQueued($row->job_reference, $row->job_task)) {
+				return false;
+			}
 
-		$queuedJob = $queuedJobsTable->createJob($row->job_task, $row->job_data, $config);
-		$row->last_run = new DateTime();
-		$row->last_queued_job_id = $queuedJob->id;
-		$this->saveOrFail($row);
+			$queuedJob = $queuedJobsTable->createJob($row->job_task, $row->job_data, $config);
 
-		return true;
+			$now = new DateTime();
+			$updated = $this->updateAll(
+				[
+					'last_run' => $now,
+					'last_queued_job_id' => $queuedJob->id,
+				],
+				[
+					'id' => $row->id,
+					'last_run IS' => $oldLastRun,
+				],
+			);
+			if ($updated === 0) {
+				// Lost the race: another tick advanced `last_run` between our
+				// isQueued() check and the updateAll. Discard the queued job
+				// to keep things idempotent for the caller.
+				$queuedJobsTable->deleteAll(['id' => $queuedJob->id]);
+
+				return false;
+			}
+
+			$row->last_run = $now;
+			$row->last_queued_job_id = $queuedJob->id;
+			// next_run is recomputed by beforeSave when last_run is dirty; the
+			// updateAll bypassed that, so do it explicitly to keep persistent
+			// state consistent without re-running the full save pipeline.
+			$row->next_run = $row->calculateNextRun();
+			$this->updateAll(
+				['next_run' => $row->next_run],
+				['id' => $row->id],
+			);
+
+			return true;
+		});
 	}
 
 	/**

--- a/tests/TestCase/Model/Entity/SchedulerRowTest.php
+++ b/tests/TestCase/Model/Entity/SchedulerRowTest.php
@@ -48,6 +48,45 @@ class SchedulerRowTest extends TestCase {
 	}
 
 	/**
+	 * Regression: a stale `next_run` whose timestamp lies in the past but
+	 * which has already been honoured by a previous tick (last_run >= next_run)
+	 * must NOT re-fire the row every subsequent tick. Without this guard a
+	 * dispatcher crash between createJob() and the next_run-update would
+	 * leave the row in an "always due" state forever.
+	 *
+	 * @return void
+	 */
+	public function testIsNotDueWhenLastRunAlreadyCaughtUpToNextRun(): void {
+		$row = new SchedulerRow([
+			'frequency' => '+5 minutes',
+			'next_run' => (new DateTime())->subSeconds(120),
+			'last_run' => (new DateTime())->subSeconds(60),
+		]);
+
+		// next_run is in the past, but last_run is more recent — the row
+		// already fired for that scheduled slot. Fall through to the
+		// frequency calculation: 60s ago + 5min < now, so still not due.
+		$this->assertFalse($row->isDue());
+	}
+
+	/**
+	 * Mirror of the regression above: when next_run is in the past AND
+	 * last_run is older than next_run, the row has NOT yet fired for that
+	 * slot — must still be due.
+	 *
+	 * @return void
+	 */
+	public function testIsDueWhenLastRunPredatesNextRun(): void {
+		$row = new SchedulerRow([
+			'frequency' => '+5 minutes',
+			'next_run' => (new DateTime())->subSeconds(60),
+			'last_run' => (new DateTime())->subSeconds(600),
+		]);
+
+		$this->assertTrue($row->isDue());
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testIsDueWhenNextRunInFuture(): void {

--- a/tests/TestCase/Model/Table/SchedulerRowsTableTest.php
+++ b/tests/TestCase/Model/Table/SchedulerRowsTableTest.php
@@ -30,6 +30,7 @@ class SchedulerRowsTableTest extends TestCase {
 	 */
 	protected array $fixtures = [
 		'plugin.QueueScheduler.SchedulerRows',
+		'plugin.Queue.QueuedJobs',
 	];
 
 	/**
@@ -489,6 +490,61 @@ class SchedulerRowsTableTest extends TestCase {
 	 * Real values pass through unchanged — the normalizer only fires on
 	 * decoded-empty arrays.
 	 *
+	 * @return void
+	 */
+	/**
+	 * Regression: `run()` wraps the isQueued → createJob → save chain in a
+	 * transaction with a compare-and-swap on `last_run`. Two scheduler ticks
+	 * landing on the same row simultaneously must result in EXACTLY ONE
+	 * queued job, with the second `run()` call returning false.
+	 *
+	 * Simulated here by calling `run()` twice in sequence and reloading the
+	 * row in between; the second call sees a `last_run` that no longer
+	 * matches the first call's snapshot, so the compare-and-swap loses the
+	 * race and rolls back the duplicate queued job.
+	 *
+	 * @return void
+	 */
+	public function testRunIsIdempotentAcrossOverlappingTicks(): void {
+		$this->loadPlugins(['Queue']);
+		$row = $this->SchedulerRows->newEntity([
+			'name' => 'race-target',
+			'type' => SchedulerRow::TYPE_QUEUE_TASK,
+			'content' => ExampleTask::class,
+			'job_config' => null,
+			'job_data' => '',
+			'frequency' => '+1 hour',
+			'allow_concurrent' => false,
+		]);
+		$this->SchedulerRows->saveOrFail($row);
+		$row = $this->SchedulerRows->get($row->id);
+		$originalLastRun = $row->last_run;
+
+		// First tick — should enqueue and advance last_run.
+		$this->assertTrue($this->SchedulerRows->run($row));
+		$row = $this->SchedulerRows->get($row->id);
+		$this->assertNotSame($originalLastRun, $row->last_run);
+		$firstQueuedId = $row->last_queued_job_id;
+		$this->assertNotNull($firstQueuedId);
+
+		$queuedJobsTable = $this->getTableLocator()->get('Queue.QueuedJobs');
+		$this->assertSame(1, $queuedJobsTable->find()->count());
+
+		// Simulate the racing tick: reload a *stale* copy of the row and call
+		// run() against it. The compare-and-swap on `last_run IS $oldLastRun`
+		// must reject the second write, and the queued job we just inserted
+		// in the racing call must be rolled back.
+		$staleRow = $this->SchedulerRows->get($row->id);
+		// Re-stamp the in-memory copy back to the pre-first-run snapshot so
+		// the racing call thinks it saw the original last_run.
+		$staleRow->last_run = $originalLastRun;
+		$result = $this->SchedulerRows->run($staleRow);
+
+		$this->assertFalse($result, 'losing tick must return false');
+		$this->assertSame(1, $queuedJobsTable->find()->count(), 'losing tick must not leave an orphan queued job');
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testNonEmptyParamIsLeftAlone(): void {

--- a/tests/TestCase/Model/Table/SchedulerRowsTableTest.php
+++ b/tests/TestCase/Model/Table/SchedulerRowsTableTest.php
@@ -506,7 +506,11 @@ class SchedulerRowsTableTest extends TestCase {
 	 * @return void
 	 */
 	public function testRunIsIdempotentAcrossOverlappingTicks(): void {
-		$this->loadPlugins(['Queue']);
+		// Load alongside Tools + QueueScheduler so the plugin registry matches
+		// what Application::bootstrap() loads in the test app. Loading only
+		// Queue would replace the registry and break later tests that rely
+		// on Tools' commands being indexed (e.g. CommandFinderTest::testAll).
+		$this->loadPlugins(['Tools', 'Queue', 'QueueScheduler']);
 		$row = $this->SchedulerRows->newEntity([
 			'name' => 'race-target',
 			'type' => SchedulerRow::TYPE_QUEUE_TASK,


### PR DESCRIPTION
## Summary

Two correctness bugs from the source-grounded review.

- **`SchedulerRow::isDue()` short-circuited on `next_run` and ignored `last_run`.** If a dispatcher crashed between `createJob()` and the `next_run`-advancing save, the row stayed in an "always due" state and re-fired on every subsequent tick — turning a single missed-save event into an unbounded duplicate-enqueue loop. Same shape happens any time `next_run` falls stale relative to a more recent `last_run`. The fix adds a guard: when both timestamps are present and `last_run >= next_run`, the row already executed for that scheduled slot, so fall through to the frequency-based path (cron or interval) instead of re-firing.
- **`SchedulerRowsTable::run()` was racy and non-transactional.** `isQueued()` → `createJob()` → write `last_run` had no transaction and no compare-and-swap. Two scheduler ticks landing on the same row simultaneously (parallel cron on one host, or — once a non-`FileLock` backend lands — two app nodes) would both pass `isQueued() === false`, both `createJob()`, both write `last_run`. Wrapped the chain in `getConnection()->transactional()` and replaced the row-level save with an `updateAll()` guarded by `['id' => $row->id, 'last_run IS' => $oldLastRun]`. If zero rows are updated the racing tick lost the CAS race; we then `deleteAll()` the queued job we just inserted to keep dispatch idempotent. The transaction makes the createJob → updateAll pair atomic so a half-applied state can't leak on failure either.

## Tests

Three new regression tests:

- `SchedulerRowTest::testIsNotDueWhenLastRunAlreadyCaughtUpToNextRun` — proves the row stops re-firing once `last_run` has caught up.
- `SchedulerRowTest::testIsDueWhenLastRunPredatesNextRun` — mirror; a row that legitimately hasn't fired for the current scheduled slot remains due.
- `SchedulerRowsTableTest::testRunIsIdempotentAcrossOverlappingTicks` — enqueues once, then drives a stale snapshot of the row through `run()` again to simulate a racing dispatcher; second call returns `false` and the queued_jobs count stays at 1.

phpunit 117/118, phpstan clean, phpcs clean. The remaining `CommandFinderTest::testAll` failure is pre-existing on master (expects `null` where `Tools\Command\InflectCommand` is now indexed) — unrelated to this PR.
