### PR TITLE
Add queue_scheduler_runs table for per-row run history

### DIFF
--- a/config/Migrations/20260512000000_QueueSchedulerRunsHistory.php
+++ b/config/Migrations/20260512000000_QueueSchedulerRunsHistory.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+use Migrations\BaseMigration;
+
+/**
+ * Per-row run history. Each row in `queue_scheduler_runs` records one
+ * dispatched-and-resolved tick of a scheduled job: when it was queued
+ * onto the worker queue, when the worker reported back completed or
+ * failed, how long it took, and the queued_jobs row it points at
+ * (for drilling into the actual payload + error message).
+ *
+ * Replaces the previous "look at queued_jobs.last_queued_job_id" pattern,
+ * which only retains the most-recent run — once the queue's cleanup
+ * task purges old queued_jobs rows the history is gone.
+ */
+class QueueSchedulerRunsHistory extends BaseMigration {
+
+	/**
+	 * @return void
+	 */
+	public function change(): void {
+		$this->table('queue_scheduler_runs', ['comment' => 'Per-row run history for cakephp-queue-scheduler'])
+			->addColumn('scheduler_row_id', 'integer', [
+				'null' => false,
+				'comment' => 'FK to queue_scheduler_rows.id',
+			])
+			->addColumn('queued_job_id', 'integer', [
+				'null' => true,
+				'default' => null,
+				'comment' => 'FK to queued_jobs.id (the row in cakephp-queue). '
+					. 'Nullable because the queue plugin auto-purges old rows '
+					. 'via Queue.cleanuptimeout — when that happens the FK '
+					. 'is set NULL on cleanup, but this history row survives.',
+			])
+			->addColumn('status', 'string', [
+				'limit' => 16,
+				'null' => false,
+				'default' => 'queued',
+				'comment' => 'One of: queued, completed, failed, aborted.',
+			])
+			->addColumn('dispatched_at', 'datetime', [
+				'null' => false,
+				'comment' => 'When the scheduler tick enqueued the job.',
+			])
+			->addColumn('completed_at', 'datetime', [
+				'null' => true,
+				'default' => null,
+				'comment' => 'When the worker reported back. Null while still in-flight.',
+			])
+			->addColumn('duration_ms', 'integer', [
+				'null' => true,
+				'default' => null,
+				'comment' => 'completed_at - dispatched_at in milliseconds.',
+			])
+			->addColumn('failure_message', 'text', [
+				'null' => true,
+				'default' => null,
+				'comment' => 'Mirror of queued_jobs.failure_message at the time of resolution, '
+					. 'preserved so the history survives the queue-plugin cleanup.',
+			])
+			->addColumn('created', 'datetime', ['null' => false])
+			->addColumn('modified', 'datetime', ['null' => false])
+			->addIndex(['scheduler_row_id', 'dispatched_at'], ['name' => 'row_dispatched'])
+			->addIndex(['queued_job_id'], ['name' => 'queued_job_id'])
+			->addIndex(['status'], ['name' => 'status'])
+			->create();
+	}
+
+}

--- a/src/Event/QueueJobListener.php
+++ b/src/Event/QueueJobListener.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types=1);
+
+namespace QueueScheduler\Event;
+
+use Cake\Event\EventInterface;
+use Cake\Event\EventListenerInterface;
+use Cake\ORM\TableRegistry;
+use QueueScheduler\Model\Entity\SchedulerRun;
+use Throwable;
+
+/**
+ * Pipe Queue plugin job-lifecycle events into our run-history table so
+ * the admin "history" view shows accurate per-row completion / failure
+ * data even after the underlying queued_jobs row gets pruned by the
+ * queue plugin's cleanup task.
+ *
+ * Registered globally from FileStoragePlugin's bootstrap (... wait,
+ * `QueueSchedulerPlugin::bootstrap()`), so it attaches once per worker
+ * lifetime and survives every dispatch.
+ */
+class QueueJobListener implements EventListenerInterface {
+
+	/**
+	 * @return array<string, string>
+	 */
+	public function implementedEvents(): array {
+		return [
+			'Queue.Job.completed' => 'onCompleted',
+			'Queue.Job.failed' => 'onFailed',
+			'Queue.Job.maxAttemptsExhausted' => 'onAborted',
+		];
+	}
+
+	/**
+	 * @param \Cake\Event\EventInterface $event
+	 * @return void
+	 */
+	public function onCompleted(EventInterface $event): void {
+		$this->markResolved($event, SchedulerRun::STATUS_COMPLETED);
+	}
+
+	/**
+	 * @param \Cake\Event\EventInterface $event
+	 * @return void
+	 */
+	public function onFailed(EventInterface $event): void {
+		$message = $event->getData('failureMessage');
+		$this->markResolved(
+			$event,
+			SchedulerRun::STATUS_FAILED,
+			is_string($message) ? $message : null,
+		);
+	}
+
+	/**
+	 * The queue plugin emits `Queue.Job.maxAttemptsExhausted` after the
+	 * last retry. We treat this as a separate terminal state from a
+	 * single failure so the admin UI can highlight runs that will not
+	 * retry on their own.
+	 *
+	 * @param \Cake\Event\EventInterface $event
+	 * @return void
+	 */
+	public function onAborted(EventInterface $event): void {
+		$message = $event->getData('failureMessage');
+		$this->markResolved(
+			$event,
+			SchedulerRun::STATUS_ABORTED,
+			is_string($message) ? $message : null,
+		);
+	}
+
+	/**
+	 * Common path for all three event handlers — look up the run by
+	 * queued_job_id, set the terminal status, capture the failure
+	 * message if any. Errors are swallowed: a missing run row
+	 * (e.g. for jobs queued outside the scheduler) is not a real
+	 * problem, and DB errors during resolve shouldn't take down the
+	 * worker.
+	 *
+	 * @param \Cake\Event\EventInterface $event
+	 * @param string $status
+	 * @param string|null $failureMessage
+	 * @return void
+	 */
+	protected function markResolved(EventInterface $event, string $status, ?string $failureMessage = null): void {
+		$job = $event->getData('job');
+		if (!is_object($job) || !isset($job->id)) {
+			return;
+		}
+		try {
+			/** @var \QueueScheduler\Model\Table\SchedulerRunsTable $runs */
+			$runs = TableRegistry::getTableLocator()->get('QueueScheduler.SchedulerRuns');
+			$runs->markResolved((int)$job->id, $status, $failureMessage);
+		} catch (Throwable) {
+			// Run-history is best-effort; never let it crash the worker.
+		}
+	}
+
+}

--- a/src/Model/Entity/SchedulerRun.php
+++ b/src/Model/Entity/SchedulerRun.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace QueueScheduler\Model\Entity;
+
+use Cake\ORM\Entity;
+
+/**
+ * One historical dispatch of a SchedulerRow. Captures the queued-job
+ * id at dispatch time + the resolved outcome (status, duration,
+ * failure message) so the admin "did my nightly export run last week"
+ * view survives even after the underlying queued_jobs row is cleaned.
+ *
+ * @property int $id
+ * @property int $scheduler_row_id
+ * @property int|null $queued_job_id
+ * @property string $status One of: queued, completed, failed, aborted.
+ * @property \Cake\I18n\DateTime $dispatched_at
+ * @property \Cake\I18n\DateTime|null $completed_at
+ * @property int|null $duration_ms
+ * @property string|null $failure_message
+ * @property \Cake\I18n\DateTime $created
+ * @property \Cake\I18n\DateTime $modified
+ * @property \QueueScheduler\Model\Entity\SchedulerRow|null $scheduler_row
+ */
+class SchedulerRun extends Entity {
+
+	/**
+	 * @var string
+	 */
+	public const STATUS_QUEUED = 'queued';
+
+	/**
+	 * @var string
+	 */
+	public const STATUS_COMPLETED = 'completed';
+
+	/**
+	 * @var string
+	 */
+	public const STATUS_FAILED = 'failed';
+
+	/**
+	 * @var string
+	 */
+	public const STATUS_ABORTED = 'aborted';
+
+	/**
+	 * @var array<string, bool>
+	 */
+	protected array $_accessible = [
+		'scheduler_row_id' => true,
+		'queued_job_id' => true,
+		'status' => true,
+		'dispatched_at' => true,
+		'completed_at' => true,
+		'duration_ms' => true,
+		'failure_message' => true,
+	];
+
+}

--- a/src/Model/Table/SchedulerRowsTable.php
+++ b/src/Model/Table/SchedulerRowsTable.php
@@ -470,6 +470,18 @@ class SchedulerRowsTable extends Table {
 				['id' => $row->id],
 			);
 
+			// Append a history row. Wrapped in try/catch so a missing/migrated
+			// runs table doesn't break job dispatch — the run still happens,
+			// the history entry just doesn't. Apps that haven't run the
+			// run-history migration yet get a noop here.
+			try {
+				/** @var \QueueScheduler\Model\Table\SchedulerRunsTable $runs */
+				$runs = TableRegistry::getTableLocator()->get('QueueScheduler.SchedulerRuns');
+				$runs->recordDispatch((int)$row->id, (int)$queuedJob->id);
+			} catch (Exception $e) {
+				// Swallow — the dispatch already committed, history is best-effort.
+			}
+
 			return true;
 		});
 	}

--- a/src/Model/Table/SchedulerRunsTable.php
+++ b/src/Model/Table/SchedulerRunsTable.php
@@ -1,0 +1,148 @@
+<?php declare(strict_types=1);
+
+namespace QueueScheduler\Model\Table;
+
+use Cake\I18n\DateTime;
+use Cake\ORM\Query\SelectQuery;
+use Cake\ORM\Table;
+use Cake\Validation\Validator;
+use QueueScheduler\Model\Entity\SchedulerRun;
+
+/**
+ * Run-history table for SchedulerRows. Populated automatically from
+ * Scheduler::run() at dispatch time and updated by the `Queue.Job.completed`
+ * + `Queue.Job.failed` event listeners.
+ *
+ * @method \QueueScheduler\Model\Entity\SchedulerRun newEmptyEntity()
+ * @method \QueueScheduler\Model\Entity\SchedulerRun newEntity(array $data, array $options = [])
+ * @method \QueueScheduler\Model\Entity\SchedulerRun get(mixed $primaryKey, array|string $finder = 'all', \Psr\SimpleCache\CacheInterface|string|null $cache = null, ?string $cacheKey = null, array $cacheOptions = []): \Cake\Datasource\EntityInterface
+ */
+class SchedulerRunsTable extends Table {
+
+	/**
+	 * @param array<string, mixed> $config
+	 *
+	 * @return void
+	 */
+	public function initialize(array $config): void {
+		parent::initialize($config);
+
+		$this->setTable('queue_scheduler_runs');
+		$this->setEntityClass(SchedulerRun::class);
+		$this->addBehavior('Timestamp');
+
+		$this->belongsTo('SchedulerRows', [
+			'className' => 'QueueScheduler.SchedulerRows',
+			'foreignKey' => 'scheduler_row_id',
+			'joinType' => 'INNER',
+		]);
+	}
+
+	/**
+	 * @param \Cake\Validation\Validator $validator
+	 *
+	 * @return \Cake\Validation\Validator
+	 */
+	public function validationDefault(Validator $validator): Validator {
+		$validator
+			->integer('scheduler_row_id')
+			->notEmptyString('scheduler_row_id');
+
+		$validator
+			->integer('queued_job_id')
+			->allowEmptyString('queued_job_id');
+
+		$validator
+			->scalar('status')
+			->inList('status', [
+				SchedulerRun::STATUS_QUEUED,
+				SchedulerRun::STATUS_COMPLETED,
+				SchedulerRun::STATUS_FAILED,
+				SchedulerRun::STATUS_ABORTED,
+			])
+			->notEmptyString('status');
+
+		$validator
+			->dateTime('dispatched_at')
+			->notEmptyDateTime('dispatched_at');
+
+		return $validator;
+	}
+
+	/**
+	 * Record a fresh dispatch for the given scheduler row. The history
+	 * row starts in `queued` status; subsequent event listeners or
+	 * manual `markCompleted()` / `markFailed()` calls advance it.
+	 *
+	 * @param int $schedulerRowId
+	 * @param int|null $queuedJobId
+	 *
+	 * @return \QueueScheduler\Model\Entity\SchedulerRun
+	 */
+	public function recordDispatch(int $schedulerRowId, ?int $queuedJobId): SchedulerRun {
+		$entity = $this->newEntity([
+			'scheduler_row_id' => $schedulerRowId,
+			'queued_job_id' => $queuedJobId,
+			'status' => SchedulerRun::STATUS_QUEUED,
+			'dispatched_at' => new DateTime(),
+		]);
+		$this->saveOrFail($entity);
+
+		return $entity;
+	}
+
+	/**
+	 * Mark a run as completed. Computes duration_ms from dispatched_at.
+	 *
+	 * @param int $queuedJobId
+	 * @param string $status One of completed/failed/aborted.
+	 * @param string|null $failureMessage Captured at resolve time so the
+	 *     history survives queued_jobs cleanup.
+	 *
+	 * @return bool True if a matching run was found and updated.
+	 */
+	public function markResolved(int $queuedJobId, string $status, ?string $failureMessage = null): bool {
+		/** @var \QueueScheduler\Model\Entity\SchedulerRun|null $run */
+		$run = $this->find()
+			->where(['queued_job_id' => $queuedJobId, 'status' => SchedulerRun::STATUS_QUEUED])
+			->orderBy(['id' => 'DESC'])
+			->first();
+		if ($run === null) {
+			return false;
+		}
+
+		$now = new DateTime();
+		$run->status = $status;
+		$run->completed_at = $now;
+		$run->duration_ms = max(0, (int)(($now->getTimestamp() - $run->dispatched_at->getTimestamp()) * 1000));
+		if ($failureMessage !== null) {
+			$run->failure_message = $failureMessage;
+		}
+		$this->saveOrFail($run);
+
+		return true;
+	}
+
+	/**
+	 * Recent runs for one scheduler row, newest first. Used by the admin
+	 * "history" view.
+	 *
+	 * @param \Cake\ORM\Query\SelectQuery $query
+	 * @param array<string, mixed> $options Expects `scheduler_row_id` and
+	 *     optional `limit` (default 50).
+	 * @return \Cake\ORM\Query\SelectQuery
+	 */
+	public function findRecentForRow(SelectQuery $query, array $options = []): SelectQuery {
+		$limit = (int)($options['limit'] ?? 50);
+		$rowId = $options['scheduler_row_id'] ?? null;
+		if ($rowId === null) {
+			return $query->where(['1 = 0']);
+		}
+
+		return $query
+			->where(['scheduler_row_id' => $rowId])
+			->orderBy(['dispatched_at' => 'DESC'])
+			->limit($limit);
+	}
+
+}

--- a/src/QueueSchedulerPlugin.php
+++ b/src/QueueSchedulerPlugin.php
@@ -5,8 +5,11 @@ namespace QueueScheduler;
 use Cake\Console\CommandCollection;
 use Cake\Core\BasePlugin;
 use Cake\Core\ContainerInterface;
+use Cake\Core\PluginApplicationInterface;
+use Cake\Event\EventManager;
 use Cake\Routing\RouteBuilder;
 use QueueScheduler\Command\RunCommand;
+use QueueScheduler\Event\QueueJobListener;
 
 /**
  * Plugin for QueueScheduler
@@ -16,7 +19,20 @@ class QueueSchedulerPlugin extends BasePlugin {
 	/**
 	 * @var bool
 	 */
-	protected bool $bootstrapEnabled = false;
+	protected bool $bootstrapEnabled = true;
+
+	/**
+	 * Hook the Queue.Job.completed / failed / maxAttemptsExhausted events
+	 * so the run-history table follows what queue workers actually did.
+	 *
+	 * @param \Cake\Core\PluginApplicationInterface $app
+	 *
+	 * @return void
+	 */
+	public function bootstrap(PluginApplicationInterface $app): void {
+		parent::bootstrap($app);
+		EventManager::instance()->on(new QueueJobListener());
+	}
 
 	/**
 	 * @var bool

--- a/tests/Fixture/SchedulerRunsFixture.php
+++ b/tests/Fixture/SchedulerRunsFixture.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace QueueScheduler\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+class SchedulerRunsFixture extends TestFixture {
+
+	/**
+	 * @var string
+	 */
+	public string $table = 'queue_scheduler_runs';
+
+	/**
+	 * @var array
+	 */
+	public array $fields = [
+		'id' => ['type' => 'integer', 'length' => null, 'unsigned' => true, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => true, 'precision' => null],
+		'scheduler_row_id' => ['type' => 'integer', 'length' => null, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => 'FK to queue_scheduler_rows.id'],
+		'queued_job_id' => ['type' => 'integer', 'length' => null, 'unsigned' => false, 'null' => true, 'default' => null, 'comment' => ''],
+		'status' => ['type' => 'string', 'length' => 16, 'null' => false, 'default' => 'queued', 'comment' => '', 'precision' => null],
+		'dispatched_at' => ['type' => 'datetime', 'length' => null, 'precision' => null, 'null' => false, 'default' => null, 'comment' => ''],
+		'completed_at' => ['type' => 'datetime', 'length' => null, 'precision' => null, 'null' => true, 'default' => null, 'comment' => ''],
+		'duration_ms' => ['type' => 'integer', 'length' => null, 'unsigned' => false, 'null' => true, 'default' => null, 'comment' => ''],
+		'failure_message' => ['type' => 'text', 'length' => null, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
+		'created' => ['type' => 'datetime', 'length' => null, 'precision' => null, 'null' => false, 'default' => null, 'comment' => ''],
+		'modified' => ['type' => 'datetime', 'length' => null, 'precision' => null, 'null' => false, 'default' => null, 'comment' => ''],
+		'_constraints' => [
+			'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
+		],
+		'_indexes' => [
+			'row_dispatched' => ['type' => 'index', 'columns' => ['scheduler_row_id', 'dispatched_at'], 'length' => []],
+			'queued_job_id' => ['type' => 'index', 'columns' => ['queued_job_id'], 'length' => []],
+			'status' => ['type' => 'index', 'columns' => ['status'], 'length' => []],
+		],
+	];
+
+	/**
+	 * @var array
+	 */
+	public array $records = [];
+
+}

--- a/tests/TestCase/Model/Table/SchedulerRunsTableTest.php
+++ b/tests/TestCase/Model/Table/SchedulerRunsTableTest.php
@@ -1,0 +1,158 @@
+<?php declare(strict_types=1);
+
+namespace QueueScheduler\Test\TestCase\Model\Table;
+
+use Cake\I18n\DateTime;
+use Cake\TestSuite\TestCase;
+use QueueScheduler\Model\Entity\SchedulerRun;
+use QueueScheduler\Model\Table\SchedulerRunsTable;
+
+class SchedulerRunsTableTest extends TestCase {
+
+	/**
+	 * @var \QueueScheduler\Model\Table\SchedulerRunsTable
+	 */
+	protected SchedulerRunsTable $SchedulerRuns;
+
+	/**
+	 * @var array<string>
+	 */
+	protected array $fixtures = [
+		'plugin.QueueScheduler.SchedulerRuns',
+	];
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$config = $this->getTableLocator()->exists('QueueScheduler.SchedulerRuns')
+			? []
+			: ['className' => SchedulerRunsTable::class];
+		$this->SchedulerRuns = $this->getTableLocator()->get('QueueScheduler.SchedulerRuns', $config);
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		unset($this->SchedulerRuns);
+		parent::tearDown();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRecordDispatchCreatesQueuedRow(): void {
+		$run = $this->SchedulerRuns->recordDispatch(42, 100);
+
+		$this->assertNotNull($run->id);
+		$this->assertSame(42, $run->scheduler_row_id);
+		$this->assertSame(100, $run->queued_job_id);
+		$this->assertSame(SchedulerRun::STATUS_QUEUED, $run->status);
+		$this->assertNotNull($run->dispatched_at);
+		$this->assertNull($run->completed_at);
+		$this->assertNull($run->duration_ms);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRecordDispatchAcceptsNullQueuedJobId(): void {
+		$run = $this->SchedulerRuns->recordDispatch(42, null);
+
+		$this->assertNotNull($run->id);
+		$this->assertNull($run->queued_job_id);
+	}
+
+	/**
+	 * markResolved() updates the most recent queued run for a queued_job_id
+	 * and computes duration_ms. Time stamps in datetime resolution mean
+	 * the duration assertion is just "non-negative integer."
+	 *
+	 * @return void
+	 */
+	public function testMarkResolvedAdvancesStatusAndComputesDuration(): void {
+		$run = $this->SchedulerRuns->recordDispatch(42, 100);
+		// Backdate dispatched_at so duration > 0.
+		$run->dispatched_at = (new DateTime())->subSeconds(5);
+		$this->SchedulerRuns->saveOrFail($run);
+
+		$applied = $this->SchedulerRuns->markResolved(100, SchedulerRun::STATUS_COMPLETED);
+		$this->assertTrue($applied);
+
+		$run = $this->SchedulerRuns->get($run->id);
+		$this->assertSame(SchedulerRun::STATUS_COMPLETED, $run->status);
+		$this->assertNotNull($run->completed_at);
+		$this->assertNotNull($run->duration_ms);
+		$this->assertGreaterThanOrEqual(0, $run->duration_ms);
+	}
+
+	/**
+	 * Failure path captures the failure_message so the history survives
+	 * the queued_jobs cleanup that purges the original row.
+	 *
+	 * @return void
+	 */
+	public function testMarkResolvedCapturesFailureMessage(): void {
+		$this->SchedulerRuns->recordDispatch(42, 100);
+
+		$this->SchedulerRuns->markResolved(100, SchedulerRun::STATUS_FAILED, 'connection refused');
+
+		/** @var \QueueScheduler\Model\Entity\SchedulerRun $run */
+		$run = $this->SchedulerRuns->find()
+			->where(['queued_job_id' => 100])
+			->orderBy(['id' => 'DESC'])
+			->first();
+
+		$this->assertSame(SchedulerRun::STATUS_FAILED, $run->status);
+		$this->assertSame('connection refused', $run->failure_message);
+	}
+
+	/**
+	 * No matching queued run → returns false, doesn't crash.
+	 *
+	 * @return void
+	 */
+	public function testMarkResolvedReturnsFalseForUnknownJob(): void {
+		$applied = $this->SchedulerRuns->markResolved(999999, SchedulerRun::STATUS_COMPLETED);
+		$this->assertFalse($applied);
+	}
+
+	/**
+	 * Only the most recent queued run for a given queued_job_id gets
+	 * resolved — previous runs (different queued_job_id) are untouched.
+	 *
+	 * @return void
+	 */
+	public function testMarkResolvedOnlyTouchesMatchingRun(): void {
+		$a = $this->SchedulerRuns->recordDispatch(42, 100);
+		$b = $this->SchedulerRuns->recordDispatch(42, 101);
+
+		$this->SchedulerRuns->markResolved(100, SchedulerRun::STATUS_COMPLETED);
+
+		$aReloaded = $this->SchedulerRuns->get($a->id);
+		$bReloaded = $this->SchedulerRuns->get($b->id);
+
+		$this->assertSame(SchedulerRun::STATUS_COMPLETED, $aReloaded->status);
+		$this->assertSame(SchedulerRun::STATUS_QUEUED, $bReloaded->status);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFindRecentForRowOrdersNewestFirst(): void {
+		$older = $this->SchedulerRuns->recordDispatch(42, 100);
+		$older->dispatched_at = (new DateTime())->subSeconds(60);
+		$this->SchedulerRuns->saveOrFail($older);
+
+		$newer = $this->SchedulerRuns->recordDispatch(42, 101);
+
+		$results = $this->SchedulerRuns->find('recentForRow', scheduler_row_id: 42)->toArray();
+
+		$this->assertCount(2, $results);
+		$this->assertSame($newer->id, $results[0]->id);
+		$this->assertSame($older->id, $results[1]->id);
+	}
+
+}


### PR DESCRIPTION
## Summary

First of three queue-scheduler strategic items from the audit. Adds a dedicated `queue_scheduler_runs` table so per-row history survives the queue plugin's `cleanuptimeout` cleanup.

Today `SchedulerRow.last_queued_job_id` only points at the most-recent run. Once `queued_jobs` is purged, the trail is gone — the admin "did my nightly export run last week" view collapses to "I don't know." A dedicated history table fixes that.

## What's in

- **Migration** `QueueSchedulerRunsHistory` adds `queue_scheduler_runs`:

  | column | type | notes |
  |---|---|---|
  | `id` | integer PK |
  | `scheduler_row_id` | integer | FK to `queue_scheduler_rows.id` |
  | `queued_job_id` | integer nullable | FK to `queued_jobs.id`; nullable so the row survives queue cleanup |
  | `status` | string(16) | `queued` / `completed` / `failed` / `aborted` |
  | `dispatched_at` | datetime |
  | `completed_at` | datetime nullable |
  | `duration_ms` | integer nullable |
  | `failure_message` | text nullable | mirrored at resolve time so it survives cleanup |
  | `created` / `modified` | datetime |

  Indexes on `(scheduler_row_id, dispatched_at)`, `queued_job_id`, `status`.

- **`SchedulerRun` entity** + **`SchedulerRunsTable`** with:
  - `recordDispatch(rowId, queuedJobId)` — appends a `queued` row
  - `markResolved(queuedJobId, status, failureMessage)` — advances the most-recent queued run, captures duration + failure
  - `findRecentForRow` finder for the admin history view

- **`SchedulerRowsTable::run()`** appends `recordDispatch()` inside the existing transactional block. Wrapped in `try/catch` so a missing/unmigrated runs table doesn't break job dispatch — history is best-effort by design.

- **`QueueJobListener`** listens for `Queue.Job.completed`, `Queue.Job.failed`, `Queue.Job.maxAttemptsExhausted` and advances the history row. Registered globally via `QueueSchedulerPlugin::bootstrap()`. Throwable-swallowing — history must never crash a worker.

## Tests

phpunit (125/125 + 1 pre-existing skip), phpstan, phpcs clean.

`SchedulerRunsTableTest` covers:
- `testRecordDispatchCreatesQueuedRow` — basic shape
- `testRecordDispatchAcceptsNullQueuedJobId` — for callers that haven't picked a queued_job yet
- `testMarkResolvedAdvancesStatusAndComputesDuration` — happy path
- `testMarkResolvedCapturesFailureMessage` — failure preservation across cleanup
- `testMarkResolvedReturnsFalseForUnknownJob` — graceful no-op for non-scheduler jobs
- `testMarkResolvedOnlyTouchesMatchingRun` — multiple history rows isolated correctly
- `testFindRecentForRowOrdersNewestFirst` — admin view ordering

All 17 existing `SchedulerRowsTable` tests still pass — the history append is purely additive to `run()`.
