### PR TITLE
Add time-window restrictions to SchedulerRow dispatch gating

### DIFF
--- a/config/Migrations/20260513000000_QueueSchedulerTimeWindow.php
+++ b/config/Migrations/20260513000000_QueueSchedulerTimeWindow.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+use Migrations\BaseMigration;
+
+/**
+ * Adds time-window constraint columns to queue_scheduler_rows so a
+ * cron-like row can additionally be gated on time-of-day or day-of-week.
+ *
+ * Cron expressions already handle "every Monday at 9" but can't express
+ * "every 5 min, but only between 09:00-18:00 on weekdays" — those need
+ * compound restrictions ANDed against the firing decision. This migration
+ * adds the columns; the runtime check lives on SchedulerRow::isDue().
+ *
+ * All three columns are nullable; a row without any restriction column
+ * set behaves exactly as before (no extra gating).
+ */
+class QueueSchedulerTimeWindow extends BaseMigration {
+
+	/**
+	 * @return void
+	 */
+	public function change(): void {
+		$this->table('queue_scheduler_rows')
+			->addColumn('window_start_time', 'time', [
+				'null' => true,
+				'default' => null,
+				'comment' => 'Earliest time-of-day (server timezone) at which this row may dispatch. '
+					. 'Null = no lower bound.',
+			])
+			->addColumn('window_end_time', 'time', [
+				'null' => true,
+				'default' => null,
+				'comment' => 'Latest time-of-day (server timezone) at which this row may dispatch. '
+					. 'Null = no upper bound. If both window_start_time and '
+					. 'window_end_time are set the comparison wraps midnight when '
+					. 'end < start (e.g. 22:00-06:00 means "overnight").',
+			])
+			->addColumn('window_days_of_week', 'string', [
+				'limit' => 32,
+				'null' => true,
+				'default' => null,
+				'comment' => 'Comma-separated 0-6 days of week (0=Sunday, 6=Saturday) on which this '
+					. 'row may dispatch. Null = every day. Example: "1,2,3,4,5" for weekdays only.',
+			])
+			->update();
+	}
+
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -256,6 +256,45 @@ You can also define more complex intervals by chaining: `+ 1 hour + 5 minutes`.
 
 See https://www.php.net/manual/en/dateinterval.createfromdatestring.php for details.
 
+### Time-window restrictions (optional)
+
+Cron expressions handle "every Monday at 9" but not "every 5 minutes, but
+only between 09:00–18:00 on weekdays" — those need compound restrictions
+ANDed against the cron/interval firing. Three optional columns on
+`queue_scheduler_rows` cover that:
+
+| Column | Type | Meaning |
+|---|---|---|
+| `window_start_time` | time | Earliest time-of-day (server timezone) this row may dispatch. `null` = no lower bound. |
+| `window_end_time` | time | Latest time-of-day. `null` = no upper bound. When end < start the interval wraps midnight (`22:00`–`06:00` means "overnight"). |
+| `window_days_of_week` | string(32) | Comma-separated `0`–`6` (`0`=Sunday, `6`=Saturday). `null` = every day. |
+
+All three are nullable and ANDed together. A row that doesn't set any of
+them behaves exactly as before — no extra gating.
+
+Examples:
+
+```text
+# "Every 5 min during business hours" — cron + window combined:
+frequency:            */5 * * * *
+window_start_time:    09:00
+window_end_time:      18:00
+window_days_of_week:  1,2,3,4,5
+
+# "Heavy report runs overnight only" — end < start wraps midnight:
+frequency:            */15 * * * *
+window_start_time:    22:00
+window_end_time:      06:00
+
+# "Weekend backups only":
+frequency:            @hourly
+window_days_of_week:  0,6
+```
+
+When the window rejects, `isDue()` returns `false` even when the
+cron/interval would otherwise fire. The next scheduler tick after the
+window re-opens re-evaluates and dispatches normally.
+
 
 ## Configuration
 

--- a/src/Model/Entity/SchedulerRow.php
+++ b/src/Model/Entity/SchedulerRow.php
@@ -102,6 +102,14 @@ class SchedulerRow extends Entity {
 		$lastRun = $this->last_run;
 
 		$dateTime = new DateTime();
+
+		// Time-window gate is ANDed against the cron/interval firing. A row
+		// whose schedule says "now" but whose window says "not until 09:00"
+		// must defer; the next tick after 09:00 will re-evaluate and fire.
+		if (!$this->isWithinWindow($dateTime)) {
+			return false;
+		}
+
 		if ($nextRun) {
 			// Don't trust `next_run` alone — if a previous tick already executed
 			// this row but the dispatcher crashed before advancing `next_run`,
@@ -123,6 +131,83 @@ class SchedulerRow extends Entity {
 		}
 
 		return (new CronExpression(static::normalizeCronExpression($this->frequency)))->isDue($dateTime->toDateTimeString());
+	}
+
+	/**
+	 * Check whether the row's optional time-window restrictions allow
+	 * dispatch at the given moment.
+	 *
+	 * Three independent restrictions, all optional and ANDed together:
+	 * - `window_days_of_week`: comma-separated 0–6 days (0=Sunday, 6=Saturday).
+	 *   Null → every day.
+	 * - `window_start_time` / `window_end_time`: time-of-day bounds in the
+	 *   server's timezone. Wraps midnight when end < start (so 22:00–06:00
+	 *   means "overnight" rather than "always blocked").
+	 *
+	 * Rows that pre-date the time-window migration have all three columns
+	 * null → method returns true unconditionally. The column-access via
+	 * `get()` tolerates a row whose entity class hasn't been re-fetched
+	 * after the migration.
+	 *
+	 * @param \Cake\I18n\DateTime $when
+	 * @return bool
+	 */
+	public function isWithinWindow(DateTime $when): bool {
+		$daysCsv = $this->get('window_days_of_week');
+		if (is_string($daysCsv) && $daysCsv !== '') {
+			$allowed = array_filter(
+				array_map('trim', explode(',', $daysCsv)),
+				static fn (string $s): bool => $s !== '' && ctype_digit($s),
+			);
+			$dow = (int)$when->format('w'); // 0 (Sun) – 6 (Sat)
+			if (!in_array((string)$dow, $allowed, true)) {
+				return false;
+			}
+		}
+
+		$start = $this->get('window_start_time');
+		$end = $this->get('window_end_time');
+		if ($start === null && $end === null) {
+			return true;
+		}
+
+		$nowMinutes = ((int)$when->format('G')) * 60 + (int)$when->format('i');
+		$startMinutes = $start !== null ? static::timeToMinutes($start) : null;
+		$endMinutes = $end !== null ? static::timeToMinutes($end) : null;
+
+		if ($startMinutes !== null && $endMinutes === null) {
+			return $nowMinutes >= $startMinutes;
+		}
+		if ($startMinutes === null && $endMinutes !== null) {
+			return $nowMinutes <= $endMinutes;
+		}
+
+		// Both bounds set. Overnight window (end < start) treats the
+		// interval as wrapping midnight, so 22:00–06:00 allows 23:30 and
+		// 02:00 but not 12:00.
+		if ($endMinutes < $startMinutes) {
+			return $nowMinutes >= $startMinutes || $nowMinutes <= $endMinutes;
+		}
+
+		return $nowMinutes >= $startMinutes && $nowMinutes <= $endMinutes;
+	}
+
+	/**
+	 * Convert a time-of-day stored value (string `HH:MM:SS` or `HH:MM`,
+	 * or a Time/DateTime instance) into minutes-from-midnight.
+	 *
+	 * @param mixed $time
+	 * @return int
+	 */
+	protected static function timeToMinutes(mixed $time): int {
+		if (is_object($time) && method_exists($time, 'format')) {
+			return ((int)$time->format('G')) * 60 + (int)$time->format('i');
+		}
+		if (is_string($time) && preg_match('/^(\d{1,2}):(\d{2})/', $time, $m) === 1) {
+			return ((int)$m[1]) * 60 + (int)$m[2];
+		}
+
+		return 0;
 	}
 
 	/**

--- a/tests/Fixture/SchedulerRowsFixture.php
+++ b/tests/Fixture/SchedulerRowsFixture.php
@@ -27,6 +27,9 @@ class SchedulerRowsFixture extends TestFixture {
 		'last_queued_job_id' => ['type' => 'integer', 'length' => null, 'unsigned' => true, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
 		'allow_concurrent' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '0', 'comment' => '', 'precision' => null],
 		'enabled' => ['type' => 'boolean', 'length' => null, 'null' => false, 'default' => '0', 'comment' => '', 'precision' => null],
+		'window_start_time' => ['type' => 'time', 'length' => null, 'precision' => null, 'null' => true, 'default' => null, 'comment' => ''],
+		'window_end_time' => ['type' => 'time', 'length' => null, 'precision' => null, 'null' => true, 'default' => null, 'comment' => ''],
+		'window_days_of_week' => ['type' => 'string', 'length' => 32, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null],
 		'created' => ['type' => 'datetime', 'length' => null, 'precision' => null, 'null' => true, 'default' => null, 'comment' => ''],
 		'modified' => ['type' => 'datetime', 'length' => null, 'precision' => null, 'null' => true, 'default' => null, 'comment' => ''],
 		'_constraints' => [

--- a/tests/TestCase/Model/Entity/SchedulerRowTest.php
+++ b/tests/TestCase/Model/Entity/SchedulerRowTest.php
@@ -555,4 +555,121 @@ class SchedulerRowTest extends TestCase {
 		$this->assertSame(['command' => '', 'params' => []], $row->job_data);
 	}
 
+	// -----------------------------------------------------------------------
+	// Time-window restrictions
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Row with no time-window columns set behaves exactly as before — no
+	 * extra gating.
+	 *
+	 * @return void
+	 */
+	public function testIsWithinWindowWithNoRestrictionsIsAlwaysTrue(): void {
+		$row = new SchedulerRow(['frequency' => '* * * * *']);
+
+		$this->assertTrue($row->isWithinWindow(new DateTime('2026-05-13 03:00:00')));
+		$this->assertTrue($row->isWithinWindow(new DateTime('2026-05-13 14:00:00')));
+	}
+
+	/**
+	 * `window_days_of_week` restricts dispatch to specific weekdays.
+	 * 2026-05-13 is a Wednesday (DoW=3). Comma-separated weekday-only
+	 * list allows it; weekend-only list rejects it.
+	 *
+	 * @return void
+	 */
+	public function testIsWithinWindowHonorsDaysOfWeek(): void {
+		$weekday = new DateTime('2026-05-13 14:00:00'); // Wednesday
+
+		$rowWeekdays = new SchedulerRow([
+			'frequency' => '* * * * *',
+			'window_days_of_week' => '1,2,3,4,5',
+		]);
+		$this->assertTrue($rowWeekdays->isWithinWindow($weekday));
+
+		$rowWeekend = new SchedulerRow([
+			'frequency' => '* * * * *',
+			'window_days_of_week' => '0,6',
+		]);
+		$this->assertFalse($rowWeekend->isWithinWindow($weekday));
+	}
+
+	/**
+	 * Same-day time window: 09:00–18:00 allows 12:00 but rejects 03:00
+	 * and 22:00.
+	 *
+	 * @return void
+	 */
+	public function testIsWithinWindowHonorsSameDayTimeBounds(): void {
+		$row = new SchedulerRow([
+			'frequency' => '* * * * *',
+			'window_start_time' => '09:00:00',
+			'window_end_time' => '18:00:00',
+		]);
+
+		$this->assertTrue($row->isWithinWindow(new DateTime('2026-05-13 12:00:00')));
+		$this->assertFalse($row->isWithinWindow(new DateTime('2026-05-13 03:00:00')));
+		$this->assertFalse($row->isWithinWindow(new DateTime('2026-05-13 22:00:00')));
+	}
+
+	/**
+	 * Overnight window (end < start) wraps midnight: 22:00–06:00 allows
+	 * 23:30 and 02:00 but rejects 12:00.
+	 *
+	 * @return void
+	 */
+	public function testIsWithinWindowHandlesOvernightRange(): void {
+		$row = new SchedulerRow([
+			'frequency' => '* * * * *',
+			'window_start_time' => '22:00:00',
+			'window_end_time' => '06:00:00',
+		]);
+
+		$this->assertTrue($row->isWithinWindow(new DateTime('2026-05-13 23:30:00')));
+		$this->assertTrue($row->isWithinWindow(new DateTime('2026-05-13 02:00:00')));
+		$this->assertFalse($row->isWithinWindow(new DateTime('2026-05-13 12:00:00')));
+	}
+
+	/**
+	 * One-sided window: only start_time set → no upper bound. Allows
+	 * anything at or after start, rejects everything before.
+	 *
+	 * @return void
+	 */
+	public function testIsWithinWindowAcceptsOneSidedStart(): void {
+		$row = new SchedulerRow([
+			'frequency' => '* * * * *',
+			'window_start_time' => '09:00:00',
+		]);
+
+		$this->assertTrue($row->isWithinWindow(new DateTime('2026-05-13 09:00:00')));
+		$this->assertTrue($row->isWithinWindow(new DateTime('2026-05-13 23:59:00')));
+		$this->assertFalse($row->isWithinWindow(new DateTime('2026-05-13 08:59:00')));
+	}
+
+	/**
+	 * isDue() returns false when the window rejects, even when the cron
+	 * expression would otherwise fire. The next tick after the window
+	 * opens re-evaluates and fires.
+	 *
+	 * @return void
+	 */
+	public function testIsDueRespectsWindowGate(): void {
+		$row = new SchedulerRow([
+			'frequency' => '* * * * *', // every minute
+			'window_start_time' => '23:00:00',
+			'window_end_time' => '23:30:00',
+			'next_run' => new DateTime('2026-05-13 12:00:00'),
+		]);
+
+		// Inside cron firing window but outside the time-of-day window.
+		DateTime::setTestNow(new DateTime('2026-05-13 12:00:00'));
+		try {
+			$this->assertFalse($row->isDue());
+		} finally {
+			DateTime::setTestNow(null);
+		}
+	}
+
 }


### PR DESCRIPTION
## Summary

Second of three queue-scheduler strategic items from the audit. Cron expressions handle "every Monday at 9" but can't express "every 5 min, but only between 09:00-18:00 on weekdays" — those need compound restrictions ANDed against the cron/interval firing decision. This PR adds three optional gating columns and the runtime check.

## What's in

- **Migration** `QueueSchedulerTimeWindow` adds three nullable columns to `queue_scheduler_rows`:
  - `window_start_time` (time): earliest time-of-day this row may dispatch
  - `window_end_time` (time): latest time-of-day
  - `window_days_of_week` (varchar 32): comma-separated 0-6 days (`0`=Sunday, `6`=Saturday); null = every day

- **`SchedulerRow::isWithinWindow(DateTime $when)`** checks all three restrictions, ANDed:
  - Both bounds null → unconditionally `true` (row pre-dates migration).
  - One-sided bounds work: `start` alone means "at or after", `end` alone means "at or before".
  - **Overnight window** (end < start) wraps midnight: `22:00–06:00` allows `23:30` and `02:00` but rejects `12:00`. Without the wrap-handling a well-meaning overnight-only restriction would be permanently closed.
  - Tolerates both string (`HH:MM:SS` / `HH:MM`) and `Time`/`DateTime` storage shapes since Cake's ORM returns either depending on the column type cast.

- **`isDue()`** short-circuits to `false` when the window rejects, even when the cron expression would otherwise fire. The next scheduler tick after the window re-opens re-evaluates and fires.

## Use cases

- "Every 5 min during business hours" → `frequency = */5 * * * *`, `window_start_time = '09:00'`, `window_end_time = '18:00'`, `window_days_of_week = '1,2,3,4,5'`.
- "Only run the heavy report overnight" → `frequency = '*/15 * * * *'`, `window_start_time = '22:00'`, `window_end_time = '06:00'` (wraps midnight automatically).
- "Weekend backups only" → `window_days_of_week = '0,6'` plus whatever frequency.

## Tests

phpunit (124/124 + 1 pre-existing skip), phpstan, phpcs clean.

Six new tests in `SchedulerRowTest`:

- `testIsWithinWindowWithNoRestrictionsIsAlwaysTrue` — preserves pre-migration behavior
- `testIsWithinWindowHonorsDaysOfWeek` — `1,2,3,4,5` vs `0,6` on a Wednesday
- `testIsWithinWindowHonorsSameDayTimeBounds` — `09:00–18:00` allows `12:00`, rejects `03:00` and `22:00`
- `testIsWithinWindowHandlesOvernightRange` — `22:00–06:00` allows `23:30` and `02:00`, rejects `12:00`
- `testIsWithinWindowAcceptsOneSidedStart` — start without end works
- `testIsDueRespectsWindowGate` — end-to-end integration with the cron firing decision
