### PR TITLE
Ad-hoc trigger-now with per-call param/job_config overrides

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,29 @@ From the GUI you can:
 
 **Note:** If you have Auth/ACL activated, make sure your admin users have access to the `QueueScheduler` plugin controllers.
 
+### Manual trigger with overrides (incident response)
+
+The row detail page offers two "Run Now" actions for Queue task rows:
+
+- **Run Now** — fires the job exactly as configured: uses the row's stored `param` and `job_config`, advances `last_run` / `next_run`, and behaves identically to a normal cron tick.
+- **Run with overrides…** — opens a collapsible form with two JSON textareas (`param` override and `job_config` override). Submitting it dispatches the job once with the override values, but **does not touch `last_run` / `next_run`**, so the row keeps firing on its regular cadence.
+
+This is intended for incident response — for example, re-running yesterday's batch with a different date range, or running a single tenant out-of-band without skipping the next scheduled run. Override dispatches still respect the row's `allow_concurrent` flag: if a job for this reference is already queued and the row disallows concurrency, the override is rejected and no extra job is enqueued.
+
+Each override dispatch is logged via Cake's `Log::write('info', …)` against the default log channel, including the row id, the queued job id, the triggering identity (when available), and a truncated copy of the payload + config that were sent. Filter or route this channel separately if you want a dedicated audit trail.
+
+Programmatic equivalent (use this from a controller or service, not from a Task):
+
+```php
+$ok = $this->SchedulerRows->runOnce($row, [
+    'job_data' => ['tenant_id' => 42, 'date_from' => '2024-01-01'],
+    'job_config' => ['priority' => 1],
+    'triggered_by' => 'oncall-rerun',
+]);
+```
+
+All three keys are optional. Omitting `job_data` reuses the row's stored param; omitting `job_config` reuses the row's stored config; a partial `job_config` (e.g. only `priority`) is merged on top of the stored config rather than replacing it wholesale.
+
 ## Scheduling
 
 Add this in your crontab to run the scheduler every minute:

--- a/src/Controller/Admin/SchedulerRowsController.php
+++ b/src/Controller/Admin/SchedulerRowsController.php
@@ -155,6 +155,20 @@ class SchedulerRowsController extends QueueSchedulerAppController {
 	}
 
 	/**
+	 * Trigger a row manually.
+	 *
+	 * Plain POST: dispatches the row as configured, exactly like a cron
+	 * tick. Advances `last_run` / `next_run` and uses the row's stored
+	 * `param` and `job_config`.
+	 *
+	 * POST with `override_param` or `override_job_config` in the body:
+	 * dispatches once with the overridden values without touching
+	 * `last_run` / `next_run`. Useful for incident-response re-runs
+	 * (e.g. "rerun yesterday's batch with a different date range").
+	 * The override is logged at info level — see
+	 * `SchedulerRowsTable::runOnce()`. Empty strings on either override
+	 * field fall back to the row's stored value.
+	 *
 	 * @param string|null $id Row id.
 	 *
 	 * @return \Cake\Http\Response|null Redirects to index, or JSON when the
@@ -164,7 +178,28 @@ class SchedulerRowsController extends QueueSchedulerAppController {
 	public function run(?string $id = null): ?Response {
 		$this->request->allowMethod(['post']);
 		$row = $this->SchedulerRows->get($id);
-		$ok = $this->SchedulerRows->run($row);
+
+		$overrideParam = $this->request->getData('override_param');
+		$overrideJobConfig = $this->request->getData('override_job_config');
+		$hasOverride = (is_string($overrideParam) && $overrideParam !== '')
+			|| (is_string($overrideJobConfig) && $overrideJobConfig !== '');
+
+		if ($hasOverride) {
+			$overrides = $this->parseRunOverrides($row, $overrideParam, $overrideJobConfig);
+			if (is_string($overrides)) {
+				$this->Flash->error($overrides);
+
+				return $this->redirect($this->referer(['action' => 'view', $id]));
+			}
+			$identity = $this->request->getAttribute('identity');
+			if (is_object($identity) && method_exists($identity, 'getIdentifier')) {
+				$overrides['triggered_by'] = (string)$identity->getIdentifier();
+			}
+			$ok = $this->SchedulerRows->runOnce($row, $overrides);
+		} else {
+			$ok = $this->SchedulerRows->run($row);
+		}
+
 		$message = $ok
 			? __d('queue_scheduler', 'The job has been added to the queue.')
 			: __d('queue_scheduler', 'The job could not be added to the queue.');
@@ -182,6 +217,47 @@ class SchedulerRowsController extends QueueSchedulerAppController {
 		}
 
 		return $this->redirect($this->referer(['action' => 'view', $id]));
+	}
+
+	/**
+	 * Validate + parse the ad-hoc override fields from the run() POST body.
+	 *
+	 * Re-uses the same JSON-shape validators the save path uses
+	 * (`validateParam`, `validateJobConfig`) so an override that wouldn't be
+	 * a valid stored value also can't be dispatched ad-hoc. Returns either
+	 * the parsed overrides array (success) or an error message string
+	 * (failure) so the caller can surface it as a flash.
+	 *
+	 * @param \QueueScheduler\Model\Entity\SchedulerRow $row
+	 * @param mixed $overrideParam Raw POST value for the param override.
+	 * @param mixed $overrideJobConfig Raw POST value for the job_config override.
+	 *
+	 * @return array{job_data?: array<mixed>|null, job_config?: array<string, mixed>|null}|string
+	 */
+	protected function parseRunOverrides(mixed $row, mixed $overrideParam, mixed $overrideJobConfig): array|string {
+		$overrides = [];
+
+		if (is_string($overrideParam) && $overrideParam !== '') {
+			$context = ['data' => ['type' => $row->type]];
+			$result = $this->SchedulerRows->validateParam($overrideParam, $context);
+			if ($result !== true) {
+				return is_string($result)
+					? __d('queue_scheduler', 'Invalid param override: {0}', $result)
+					: __d('queue_scheduler', 'Invalid param override JSON.');
+			}
+			$decoded = json_decode($overrideParam, true);
+			$overrides['job_data'] = is_array($decoded) ? $decoded : null;
+		}
+
+		if (is_string($overrideJobConfig) && $overrideJobConfig !== '') {
+			if (!$this->SchedulerRows->validateJobConfig($overrideJobConfig, ['data' => []])) {
+				return __d('queue_scheduler', 'Invalid job_config override — must be a JSON object with allowed keys (priority, group).');
+			}
+			$decoded = json_decode($overrideJobConfig, true);
+			$overrides['job_config'] = is_array($decoded) ? $decoded : null;
+		}
+
+		return $overrides;
 	}
 
 	/**

--- a/src/Model/Table/SchedulerRowsTable.php
+++ b/src/Model/Table/SchedulerRowsTable.php
@@ -9,6 +9,7 @@ use Cake\Core\Configure;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\I18n\DateTime;
+use Cake\Log\Log;
 use Cake\ORM\Query\SelectQuery;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
@@ -470,6 +471,92 @@ class SchedulerRowsTable extends Table {
 				['id' => $row->id],
 			);
 
+			return true;
+		});
+	}
+
+	/**
+	 * Ad-hoc dispatch of a row with per-call overrides for the queue payload
+	 * and/or queue config. Intended for incident-response "trigger now"
+	 * actions from the admin UI: the override fires in addition to the row's
+	 * normal schedule rather than replacing it, so `last_run` / `next_run`
+	 * are NOT advanced.
+	 *
+	 * The override map accepts:
+	 *
+	 * - `job_data` — replacement payload. Shape must match the row type
+	 *   (Queue Task → array, Cake Command → list, Shell Command → empty).
+	 *   Pass `null` here to keep the row's stored `param`.
+	 * - `job_config` — replacement config (`priority`, `group`). Merged on
+	 *   top of the row's stored `job_config` so partial overrides work
+	 *   without zeroing other keys. Pass `null` to keep stored config.
+	 *
+	 * Concurrency: respects `allow_concurrent` the same way the cron path
+	 * does. An override-dispatch against an in-flight non-concurrent row
+	 * returns `false` instead of dual-firing.
+	 *
+	 * Audit: every override is logged at `info` level with a
+	 * `[QueueScheduler.Override]` prefix capturing the row id, the override
+	 * payload, and the resulting `queued_jobs.id`. There is intentionally
+	 * no override-history table — the queue plugin's `queued_jobs` row
+	 * already retains the dispatched payload until cleanup, and the log
+	 * captures the "who triggered this" piece that doesn't fit there.
+	 *
+	 * @param \QueueScheduler\Model\Entity\SchedulerRow $row
+	 * @param array{job_data?: array<mixed>|null, job_config?: array<string, mixed>|null, triggered_by?: string|null} $overrides
+	 *
+	 * @return bool True if the job was enqueued; false if blocked by
+	 *     `allow_concurrent` against an in-flight job.
+	 */
+	public function runOnce(SchedulerRow $row, array $overrides = []): bool {
+		if ($row->job_task === null) {
+			throw new RuntimeException('Cannot add job task for ' . $row->name);
+		}
+
+		$jobData = array_key_exists('job_data', $overrides) && $overrides['job_data'] !== null
+			? $overrides['job_data']
+			: $row->job_data;
+
+		// Merge instead of replace so an override that only sets `priority`
+		// preserves the row's `group` (and vice versa). The override values
+		// win on key collision.
+		$config = $row->job_config;
+		if (isset($overrides['job_config'])) {
+			$config = array_merge($config, $overrides['job_config']);
+		}
+		$config['reference'] = $row->job_reference;
+
+		return $this->getConnection()->transactional(function () use ($row, $jobData, $config, $overrides): bool {
+			/** @var \Queue\Model\Table\QueuedJobsTable $queuedJobsTable */
+			$queuedJobsTable = TableRegistry::getTableLocator()->get('Queue.QueuedJobs');
+			if (!$row->allow_concurrent && $queuedJobsTable->isQueued($row->job_reference, $row->job_task)) {
+				return false;
+			}
+
+			$queuedJob = $queuedJobsTable->createJob($row->job_task, $jobData, $config);
+
+			// Audit trail — info-level so it lands in the host app's
+			// standard log channel. Trim the override payload to a sane
+			// length to keep log files manageable; full data lives on the
+			// queued_jobs row itself for the lifetime of the queue's
+			// cleanup window.
+			Log::write('info', sprintf(
+				'[QueueScheduler.Override] Row #%d (%s) dispatched ad-hoc as queued_jobs #%d%s. Payload: %s',
+				(int)$row->id,
+				(string)$row->name,
+				(int)$queuedJob->id,
+				isset($overrides['triggered_by']) && $overrides['triggered_by'] !== ''
+					? ' by ' . substr((string)$overrides['triggered_by'], 0, 128)
+					: '',
+				substr(json_encode([
+					'job_data' => $jobData,
+					'job_config' => $config,
+				]) ?: '[]', 0, 4096),
+			));
+
+			// Deliberately do NOT touch last_run / next_run. The override
+			// is an extra dispatch on top of the scheduled cadence; the
+			// cron-fired rail continues to tick at its normal time.
 			return true;
 		});
 	}

--- a/templates/Admin/SchedulerRows/view.php
+++ b/templates/Admin/SchedulerRows/view.php
@@ -8,6 +8,7 @@
 
 $intervalSec = $row->calculateIntervalSeconds();
 $frequencyDescription = $row->getFrequencyDescription();
+$isQueueTask = $row->type === \QueueScheduler\Model\Entity\SchedulerRow::TYPE_QUEUE_TASK;
 ?>
 <div class="scheduler-rows-view">
 	<div class="d-flex justify-content-between align-items-center mb-4">
@@ -32,6 +33,11 @@ $frequencyDescription = $row->getFrequencyDescription();
 					],
 				],
 			) ?>
+			<?php if ($isQueueTask) { ?>
+				<button type="button" class="btn btn-outline-success me-2" data-bs-toggle="collapse" data-bs-target="#scheduler-run-override" aria-expanded="false" aria-controls="scheduler-run-override">
+					<i class="fas fa-sliders-h me-1"></i><?= __d('queue_scheduler', 'Run with overrides…') ?>
+				</button>
+			<?php } ?>
 			<?= $this->Form->postButton(
 				'<i class="fas fa-trash me-1"></i>' . __d('queue_scheduler', 'Delete'),
 				['action' => 'delete', $row->id],
@@ -46,6 +52,55 @@ $frequencyDescription = $row->getFrequencyDescription();
 			) ?>
 		</div>
 	</div>
+
+	<?php if ($isQueueTask) { ?>
+		<div class="collapse mb-4" id="scheduler-run-override">
+			<div class="card border-success">
+				<div class="card-header bg-success-subtle">
+					<i class="fas fa-sliders-h me-2"></i><?= __d('queue_scheduler', 'Ad-hoc trigger with overrides') ?>
+				</div>
+				<div class="card-body">
+					<p class="text-muted small mb-3">
+						<?= __d('queue_scheduler', 'This dispatches the job once with the values below, in addition to the normal schedule. {0}last_run{1} and {0}next_run{1} are NOT advanced, so the row keeps firing on its regular cadence. Each override dispatch is logged at info level. Leave a field blank to use the row\'s stored value.', '<code>', '</code>') ?>
+					</p>
+					<?= $this->Form->create(null, [
+						'url' => ['action' => 'run', $row->id],
+						'class' => 'js-scheduler-run-form',
+						'data-confirm-message' => __d('queue_scheduler', 'Dispatch this job once with the overrides below?'),
+					]) ?>
+					<div class="row">
+						<div class="col-md-6 mb-3">
+							<?= $this->Form->control('override_param', [
+								'type' => 'textarea',
+								'label' => __d('queue_scheduler', 'Param override (JSON)'),
+								'placeholder' => '{"tenant_id": 42}',
+								'value' => $row->param,
+								'rows' => 4,
+								'class' => 'form-control font-monospace',
+								'help' => __d('queue_scheduler', 'Sent as the queue job payload. Must be a valid JSON object.'),
+							]) ?>
+						</div>
+						<div class="col-md-6 mb-3">
+							<?= $this->Form->control('override_job_config', [
+								'type' => 'textarea',
+								'label' => __d('queue_scheduler', 'Job config override (JSON)'),
+								'placeholder' => '{"priority": 1}',
+								'value' => $row->job_config ? (string)json_encode($row->job_config) : '',
+								'rows' => 4,
+								'class' => 'form-control font-monospace',
+								'help' => __d('queue_scheduler', 'Allowed keys: priority (1-10), group. Merged on top of the row\'s stored job_config.'),
+							]) ?>
+						</div>
+					</div>
+					<?= $this->Form->button(
+						'<i class="fas fa-play me-1"></i>' . __d('queue_scheduler', 'Dispatch override now'),
+						['class' => 'btn btn-success', 'escapeTitle' => false, 'type' => 'submit'],
+					) ?>
+					<?= $this->Form->end() ?>
+				</div>
+			</div>
+		</div>
+	<?php } ?>
 
 	<div class="row">
 		<div class="col-lg-6 mb-4">

--- a/templates/layout/queue_scheduler.php
+++ b/templates/layout/queue_scheduler.php
@@ -335,6 +335,13 @@ $nonceAttr = $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '';
 			text-decoration: line-through;
 			color: var(--scheduler-secondary);
 		}
+
+		/* Lighter placeholder so it doesn't get mistaken for real content */
+		.form-control::placeholder,
+		.form-select::placeholder {
+			color: #adb5bd;
+			opacity: 1;
+		}
 	</style>
 
 	<?= $this->fetch('meta') ?>

--- a/tests/TestCase/Controller/Admin/SchedulerRowsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/SchedulerRowsControllerTest.php
@@ -22,6 +22,20 @@ class SchedulerRowsControllerTest extends TestCase {
 	];
 
 	/**
+	 * The `queued_jobs` table is owned by the Queue plugin and is not
+	 * fixture-managed here, so leftover rows from one test can bleed into
+	 * the next (e.g. an allow_concurrent=false row whose reference still
+	 * has a queued job from a sibling test gets blocked from dispatching).
+	 * Truncate once per test to keep the suite order-independent.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->fetchTable('Queue.QueuedJobs')->deleteAll(['1=1']);
+	}
+
+	/**
 	 * Test index method
 	 *
 	 * @return void
@@ -228,6 +242,80 @@ class SchedulerRowsControllerTest extends TestCase {
 
 		$queuedJob = $this->fetchTable('Queue.QueuedJobs')->find()->orderByDesc('id')->firstOrFail();
 		$this->assertSame('queue-scheduler-1', $queuedJob->reference);
+	}
+
+	/**
+	 * Submitting `override_param` with a valid JSON object routes through
+	 * runOnce(): the queued job's data reflects the override payload and
+	 * the row's last_run / next_run stay frozen.
+	 *
+	 * @return void
+	 */
+	public function testRunWithJobDataOverrideUsesRunOnce(): void {
+		$this->disableErrorHandlerMiddleware();
+
+		$rowsTable = $this->fetchTable('QueueScheduler.SchedulerRows');
+		$row = $rowsTable->newEntity([
+			'name' => 'Override Target',
+			'type' => 0,
+			'content' => 'Queue\\Queue\\Task\\ExampleTask',
+			'frequency' => '+ 30 seconds',
+			'enabled' => 1,
+			'last_run' => '2024-01-15 12:00:00',
+			'allow_concurrent' => 1,
+		]);
+		$rowsTable->saveOrFail($row);
+		$before = $rowsTable->get($row->id);
+
+		$this->post(
+			['prefix' => 'Admin', 'plugin' => 'QueueScheduler', 'controller' => 'SchedulerRows', 'action' => 'run', $row->id],
+			['override_param' => '{"tenant_id":99}'],
+		);
+
+		$this->assertResponseCode(302);
+
+		$queuedJob = $this->fetchTable('Queue.QueuedJobs')->find()->orderByDesc('id')->firstOrFail();
+		$payload = is_array($queuedJob->data) ? $queuedJob->data : json_decode((string)$queuedJob->data, true);
+		$this->assertSame(['tenant_id' => 99], $payload);
+
+		$after = $rowsTable->get($row->id);
+		$this->assertSame(
+			$before->last_run ? $before->last_run->format('Y-m-d H:i:s') : null,
+			$after->last_run ? $after->last_run->format('Y-m-d H:i:s') : null,
+			'override dispatch must not advance last_run',
+		);
+	}
+
+	/**
+	 * Invalid override JSON must be rejected with a flash error rather than
+	 * silently swallowed or 500-ing. No job is enqueued.
+	 *
+	 * @return void
+	 */
+	public function testRunWithInvalidOverrideFlashesError(): void {
+		$this->disableErrorHandlerMiddleware();
+		$this->enableRetainFlashMessages();
+
+		$rowsTable = $this->fetchTable('QueueScheduler.SchedulerRows');
+		$row = $rowsTable->newEntity([
+			'name' => 'Override Target',
+			'type' => 0,
+			'content' => 'Queue\\Queue\\Task\\ExampleTask',
+			'frequency' => '+ 30 seconds',
+			'enabled' => 1,
+		]);
+		$rowsTable->saveOrFail($row);
+
+		$queuedJobsTable = $this->fetchTable('Queue.QueuedJobs');
+		$before = $queuedJobsTable->find()->count();
+
+		$this->post(
+			['prefix' => 'Admin', 'plugin' => 'QueueScheduler', 'controller' => 'SchedulerRows', 'action' => 'run', $row->id],
+			['override_param' => '{not json}'],
+		);
+
+		$this->assertResponseCode(302);
+		$this->assertSame($before, $queuedJobsTable->find()->count(), 'No job should have been queued for a rejected override.');
 	}
 
 	/**

--- a/tests/TestCase/Model/Table/SchedulerRowsTableTest.php
+++ b/tests/TestCase/Model/Table/SchedulerRowsTableTest.php
@@ -549,6 +549,147 @@ class SchedulerRowsTableTest extends TestCase {
 	}
 
 	/**
+	 * runOnce() dispatches an ad-hoc job without advancing last_run /
+	 * next_run, and uses the row's stored param when no override is
+	 * provided. The scheduled cadence stays untouched.
+	 *
+	 * @return void
+	 */
+	public function testRunOnceWithoutOverridesUsesStoredParamAndPreservesCadence(): void {
+		$this->loadPlugins(['Tools', 'Queue', 'QueueScheduler']);
+		$row = $this->SchedulerRows->newEntity([
+			'name' => 'override-target',
+			'type' => SchedulerRow::TYPE_QUEUE_TASK,
+			'content' => ExampleTask::class,
+			'param' => '{"original":true}',
+			'job_config' => null,
+			'frequency' => '+1 hour',
+			'allow_concurrent' => true,
+		]);
+		$this->SchedulerRows->saveOrFail($row);
+		$row = $this->SchedulerRows->get($row->id);
+		$originalLastRun = $row->last_run;
+		$originalNextRun = $row->next_run;
+
+		$this->assertTrue($this->SchedulerRows->runOnce($row));
+
+		$queuedJobsTable = $this->getTableLocator()->get('Queue.QueuedJobs');
+		$this->assertSame(1, $queuedJobsTable->find()->count());
+
+		$reloaded = $this->SchedulerRows->get($row->id);
+		$this->assertSame(
+			$originalLastRun ? $originalLastRun->format('Y-m-d H:i:s') : null,
+			$reloaded->last_run ? $reloaded->last_run->format('Y-m-d H:i:s') : null,
+			'last_run must NOT advance for ad-hoc override dispatch',
+		);
+		$this->assertSame(
+			$originalNextRun ? $originalNextRun->format('Y-m-d H:i:s') : null,
+			$reloaded->next_run ? $reloaded->next_run->format('Y-m-d H:i:s') : null,
+			'next_run must NOT advance for ad-hoc override dispatch',
+		);
+	}
+
+	/**
+	 * runOnce() with a job_data override sends the override payload to
+	 * the queue, not the row's stored param.
+	 *
+	 * @return void
+	 */
+	public function testRunOnceWithJobDataOverrideUsesOverridePayload(): void {
+		$this->loadPlugins(['Tools', 'Queue', 'QueueScheduler']);
+		$row = $this->SchedulerRows->newEntity([
+			'name' => 'override-target',
+			'type' => SchedulerRow::TYPE_QUEUE_TASK,
+			'content' => ExampleTask::class,
+			'param' => '{"original":true}',
+			'job_config' => null,
+			'frequency' => '+1 hour',
+			'allow_concurrent' => true,
+		]);
+		$this->SchedulerRows->saveOrFail($row);
+		$row = $this->SchedulerRows->get($row->id);
+
+		$this->assertTrue($this->SchedulerRows->runOnce($row, [
+			'job_data' => ['tenant_id' => 42, 'force' => true],
+		]));
+
+		/** @var \Queue\Model\Entity\QueuedJob $queued */
+		$queued = $this->getTableLocator()
+			->get('Queue.QueuedJobs')
+			->find()
+			->orderBy(['id' => 'DESC'])
+			->first();
+		$payload = is_array($queued->data) ? $queued->data : json_decode((string)$queued->data, true);
+
+		$this->assertSame(['tenant_id' => 42, 'force' => true], $payload);
+	}
+
+	/**
+	 * runOnce() with a partial job_config override merges with the row's
+	 * stored config rather than wiping the other keys. An override that
+	 * only sets `priority` preserves the stored `group` (and vice versa).
+	 *
+	 * @return void
+	 */
+	public function testRunOnceMergesPartialJobConfigOverride(): void {
+		$this->loadPlugins(['Tools', 'Queue', 'QueueScheduler']);
+		$row = $this->SchedulerRows->newEntity([
+			'name' => 'override-target',
+			'type' => SchedulerRow::TYPE_QUEUE_TASK,
+			'content' => ExampleTask::class,
+			'param' => '',
+			'job_config' => '{"priority":8,"group":"batch"}',
+			'frequency' => '+1 hour',
+			'allow_concurrent' => true,
+		]);
+		$this->SchedulerRows->saveOrFail($row);
+		$row = $this->SchedulerRows->get($row->id);
+
+		$this->assertTrue($this->SchedulerRows->runOnce($row, [
+			'job_config' => ['priority' => 1],
+		]));
+
+		/** @var \Queue\Model\Entity\QueuedJob $queued */
+		$queued = $this->getTableLocator()
+			->get('Queue.QueuedJobs')
+			->find()
+			->orderBy(['id' => 'DESC'])
+			->first();
+
+		// The queued job's priority should reflect the override; the group
+		// from the row's stored config should still be applied.
+		$this->assertSame(1, (int)$queued->priority);
+	}
+
+	/**
+	 * runOnce() respects allow_concurrent the same way the scheduled path
+	 * does — an override against a non-concurrent row with an in-flight
+	 * job returns false instead of dual-firing.
+	 *
+	 * @return void
+	 */
+	public function testRunOnceRespectsAllowConcurrent(): void {
+		$this->loadPlugins(['Tools', 'Queue', 'QueueScheduler']);
+		$row = $this->SchedulerRows->newEntity([
+			'name' => 'override-target',
+			'type' => SchedulerRow::TYPE_QUEUE_TASK,
+			'content' => ExampleTask::class,
+			'param' => '',
+			'job_config' => null,
+			'frequency' => '+1 hour',
+			'allow_concurrent' => false,
+		]);
+		$this->SchedulerRows->saveOrFail($row);
+		$row = $this->SchedulerRows->get($row->id);
+
+		// First dispatch enqueues; second must be blocked by allow_concurrent.
+		$this->assertTrue($this->SchedulerRows->runOnce($row));
+		$this->assertFalse($this->SchedulerRows->runOnce($row));
+
+		$this->assertSame(1, $this->getTableLocator()->get('Queue.QueuedJobs')->find()->count());
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testNonEmptyParamIsLeftAlone(): void {


### PR DESCRIPTION
## Summary

Adds a second "Run Now" path for Queue task rows in the admin UI: dispatch a single override job with custom `param` and/or `job_config`, without touching the row's scheduled cadence.

**Use case:** incident-response re-runs — rerun yesterday's batch with a different date range, rerun a single tenant out-of-band, etc. The goal is one extra dispatch, not a schedule shift.

## How it works

- New `SchedulerRowsTable::runOnce(row, overrides)` enqueues with optional `job_data` / `job_config` overrides. `job_config` is merged on top of the row's stored config so partial overrides keep unrelated keys (override `priority` and keep the row's `group`, or vice versa).
- Respects `allow_concurrent`: if a job for this reference is already queued and the row disallows concurrency, the override is rejected (returns `false`) rather than dual-firing. Same semantics as the scheduled path.
- `last_run` / `next_run` are intentionally **not** touched — the row keeps firing on its normal cadence.
- Each override dispatch is logged at info level on the default Cake log channel with row id, queued job id, triggering identity (when available), and a truncated payload snapshot for audit.
- Controller wires `override_param` / `override_job_config` from the POST body through the same `validateParam` / `validateJobConfig` validators the save path uses, so an override that wouldn't be a valid stored value also can't be dispatched ad-hoc.
- View page gets a collapsible "Run with overrides..." form next to the existing Run Now button (Queue task rows only — Shell / Command rows still show only the plain Run Now).

## UI

The form is collapsed by default. Clicking the new outline-success button reveals two JSON textareas pre-populated with the row's stored values. Submitting dispatches the override; an invalid override surfaces a flash error and enqueues nothing.

## Programmatic equivalent

Both keys optional; partial `job_config` is merged with the row's stored config rather than replacing it:

```php
$ok = $this->SchedulerRows->runOnce($row, [
    'job_data' => ['tenant_id' => 42, 'date_from' => '2024-01-01'],
    'job_config' => ['priority' => 1],
    'triggered_by' => 'oncall-rerun',
]);
```

## Why not a force-bypass checkbox?

`allow_concurrent` is the row's existing answer to "is it safe to run this in parallel with itself?". A per-trigger "force" toggle would split that decision across two surfaces and create the exact failure mode the flag was designed to prevent. If a row needs to allow ad-hoc parallel runs, flip `allow_concurrent` on the row — same control point, same semantics.