### PR TITLE
Complete time-window scheduler UX and localization

### DIFF
--- a/resources/locales/de/queue_scheduler.po
+++ b/resources/locales/de/queue_scheduler.po
@@ -1,0 +1,78 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2026-05-12 00:00+0000\n"
+"PO-Revision-Date: 2026-05-12 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"Language: de_DE\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "The job is outside its configured dispatch window. Use \"Run with overrides\" for an ad-hoc exception."
+msgstr "Der Job liegt außerhalb seines konfigurierten Ausführungsfensters. Verwende „Mit Overrides ausführen“ für eine einmalige Ausnahme."
+
+msgid "Dispatch Window (optional)"
+msgstr "Ausführungsfenster (optional)"
+
+msgid "Restrictions configured"
+msgstr "Einschränkungen gesetzt"
+
+msgid "No restrictions"
+msgstr "Keine Einschränkungen"
+
+msgid "Hide"
+msgstr "Ausblenden"
+
+msgid "Configure"
+msgstr "Konfigurieren"
+
+msgid "Start"
+msgstr "Start"
+
+msgid "24h format HH:MM. Leave blank for no lower bound."
+msgstr "24h-Format HH:MM. Leer lassen für keine Untergrenze."
+
+msgid "End"
+msgstr "Ende"
+
+msgid "24h format HH:MM. Earlier than start means overnight."
+msgstr "24h-Format HH:MM. Früher als Start bedeutet über Nacht."
+
+msgid "Mon"
+msgstr "Mo"
+
+msgid "Tue"
+msgstr "Di"
+
+msgid "Wed"
+msgstr "Mi"
+
+msgid "Thu"
+msgstr "Do"
+
+msgid "Fri"
+msgstr "Fr"
+
+msgid "Sat"
+msgstr "Sa"
+
+msgid "Sun"
+msgstr "So"
+
+msgid "Allowed Days"
+msgstr "Erlaubte Tage"
+
+msgid "Leave all unchecked for every day."
+msgstr "Alles abgewählt lassen für jeden Tag."
+
+msgid "Weekday-only example: Mon-Fri."
+msgstr "Beispiel nur werktags: Mo-Fr."
+
+msgid "Run with overrides…"
+msgstr "Mit Overrides ausführen…"

--- a/resources/locales/queue_scheduler.pot
+++ b/resources/locales/queue_scheduler.pot
@@ -35,6 +35,9 @@ msgstr ""
 msgid "The job could not be added to the queue."
 msgstr ""
 
+msgid "The job is outside its configured dispatch window. Use \"Run with overrides\" for an ad-hoc exception."
+msgstr ""
+
 msgid "All jobs have been disabled"
 msgstr ""
 
@@ -117,6 +120,66 @@ msgid "Queue Scheduler"
 msgstr ""
 
 msgid "New Schedule"
+msgstr ""
+
+msgid "Dispatch Window (optional)"
+msgstr ""
+
+msgid "Restrictions configured"
+msgstr ""
+
+msgid "No restrictions"
+msgstr ""
+
+msgid "Hide"
+msgstr ""
+
+msgid "Configure"
+msgstr ""
+
+msgid "Start"
+msgstr ""
+
+msgid "24h format HH:MM. Leave blank for no lower bound."
+msgstr ""
+
+msgid "End"
+msgstr ""
+
+msgid "24h format HH:MM. Earlier than start means overnight."
+msgstr ""
+
+msgid "Mon"
+msgstr ""
+
+msgid "Tue"
+msgstr ""
+
+msgid "Wed"
+msgstr ""
+
+msgid "Thu"
+msgstr ""
+
+msgid "Fri"
+msgstr ""
+
+msgid "Sat"
+msgstr ""
+
+msgid "Sun"
+msgstr ""
+
+msgid "Allowed Days"
+msgstr ""
+
+msgid "Leave all unchecked for every day."
+msgstr ""
+
+msgid "Weekday-only example: Mon-Fri."
+msgstr ""
+
+msgid "Run with overrides…"
 msgstr ""
 
 msgid "Addon to run commands and queue tasks as crontab like database driven schedule."
@@ -424,4 +487,3 @@ msgstr ""
 
 msgid "Server Time"
 msgstr ""
-

--- a/src/Controller/Admin/SchedulerRowsController.php
+++ b/src/Controller/Admin/SchedulerRowsController.php
@@ -3,6 +3,7 @@
 namespace QueueScheduler\Controller\Admin;
 
 use Cake\Http\Response;
+use Cake\I18n\DateTime;
 
 /**
  * Rows Controller
@@ -200,9 +201,13 @@ class SchedulerRowsController extends QueueSchedulerAppController {
 			$ok = $this->SchedulerRows->run($row);
 		}
 
-		$message = $ok
-			? __d('queue_scheduler', 'The job has been added to the queue.')
-			: __d('queue_scheduler', 'The job could not be added to the queue.');
+		if ($ok) {
+			$message = __d('queue_scheduler', 'The job has been added to the queue.');
+		} elseif (!$hasOverride && !$row->isWithinWindow(new DateTime())) {
+			$message = __d('queue_scheduler', 'The job is outside its configured dispatch window. Use "Run with overrides" for an ad-hoc exception.');
+		} else {
+			$message = __d('queue_scheduler', 'The job could not be added to the queue.');
+		}
 
 		if ($this->request->is(['ajax', 'json'])) {
 			return $this->response

--- a/src/Model/Entity/SchedulerRow.php
+++ b/src/Model/Entity/SchedulerRow.php
@@ -375,13 +375,13 @@ class SchedulerRow extends Entity {
 			$allowed[$day] = $day;
 		}
 
-		if ($allowed === []) {
+		if (!$allowed) {
 			return null;
 		}
 
 		sort($allowed);
 
-		return array_values($allowed);
+		return $allowed;
 	}
 
 	/**
@@ -407,6 +407,9 @@ class SchedulerRow extends Entity {
 		}
 		if ($startSeconds === null && $endSeconds !== null) {
 			return [[0, $endSeconds]];
+		}
+		if ($startSeconds === null || $endSeconds === null) {
+			return null;
 		}
 		if ($endSeconds < $startSeconds) {
 			return [

--- a/src/Model/Entity/SchedulerRow.php
+++ b/src/Model/Entity/SchedulerRow.php
@@ -24,6 +24,9 @@ use Tools\Model\Entity\Entity;
  * @property string $frequency
  * @property \Cake\I18n\DateTime|null $last_run
  * @property \Cake\I18n\DateTime|null $next_run
+ * @property mixed $window_start_time
+ * @property mixed $window_end_time
+ * @property string|null $window_days_of_week
  * @property bool $allow_concurrent
  * @property \Cake\I18n\DateTime|null $created
  * @property \Cake\I18n\DateTime|null $modified
@@ -153,14 +156,13 @@ class SchedulerRow extends Entity {
 	 * @return bool
 	 */
 	public function isWithinWindow(DateTime $when): bool {
-		$daysCsv = $this->get('window_days_of_week');
-		if (is_string($daysCsv) && $daysCsv !== '') {
-			$allowed = array_filter(
-				array_map('trim', explode(',', $daysCsv)),
-				static fn (string $s): bool => $s !== '' && ctype_digit($s),
-			);
+		$allowed = $this->allowedWindowDays();
+		if (is_string($this->get('window_days_of_week')) && $this->get('window_days_of_week') !== '' && $allowed === null) {
+			return false;
+		}
+		if ($allowed !== null) {
 			$dow = (int)$when->format('w'); // 0 (Sun) – 6 (Sat)
-			if (!in_array((string)$dow, $allowed, true)) {
+			if (!in_array($dow, $allowed, true)) {
 				return false;
 			}
 		}
@@ -174,6 +176,9 @@ class SchedulerRow extends Entity {
 		$nowMinutes = ((int)$when->format('G')) * 60 + (int)$when->format('i');
 		$startMinutes = $start !== null ? static::timeToMinutes($start) : null;
 		$endMinutes = $end !== null ? static::timeToMinutes($end) : null;
+		if (($start !== null && $startMinutes === null) || ($end !== null && $endMinutes === null)) {
+			return false;
+		}
 
 		if ($startMinutes !== null && $endMinutes === null) {
 			return $nowMinutes >= $startMinutes;
@@ -193,21 +198,79 @@ class SchedulerRow extends Entity {
 	}
 
 	/**
+	 * Earliest instant at or after `$from` that satisfies the configured time
+	 * window. Used for interval schedules so `next_run` does not sit in the
+	 * past for hours while a row is intentionally held closed.
+	 *
+	 * @param \Cake\I18n\DateTime $from
+	 * @return \Cake\I18n\DateTime|null
+	 */
+	public function nextWindowOpenAt(DateTime $from): ?DateTime {
+		if (!$this->hasWindowRestrictions()) {
+			return $from;
+		}
+
+		$allowed = $this->allowedWindowDays();
+		if (is_string($this->get('window_days_of_week')) && $this->get('window_days_of_week') !== '' && $allowed === null) {
+			return null;
+		}
+
+		$intervals = $this->windowIntervalsByDay();
+		if ($intervals === null) {
+			return null;
+		}
+
+		for ($offsetDays = 0; $offsetDays <= 14; $offsetDays++) {
+			$day = $offsetDays === 0 ? $from : $from->addDays($offsetDays);
+			$dow = (int)$day->format('w');
+			if ($allowed !== null && !in_array($dow, $allowed, true)) {
+				continue;
+			}
+
+			$date = $day->format('Y-m-d');
+			foreach ($intervals as [$startSeconds, $endSeconds]) {
+				$candidate = new DateTime($date . ' 00:00:00');
+				$candidate = $candidate->addSeconds($startSeconds);
+				if ($candidate->getTimestamp() < $from->getTimestamp()) {
+					if ($from->format('Y-m-d') !== $date) {
+						continue;
+					}
+					if ($from->getTimestamp() > (new DateTime($date . ' 00:00:00'))->addSeconds($endSeconds)->getTimestamp()) {
+						continue;
+					}
+
+					return $from;
+				}
+
+				return $candidate;
+			}
+		}
+
+		return null;
+	}
+
+	/**
 	 * Convert a time-of-day stored value (string `HH:MM:SS` or `HH:MM`,
 	 * or a Time/DateTime instance) into minutes-from-midnight.
 	 *
 	 * @param mixed $time
-	 * @return int
+	 * @return int|null
 	 */
-	protected static function timeToMinutes(mixed $time): int {
+	protected static function timeToMinutes(mixed $time): ?int {
 		if (is_object($time) && method_exists($time, 'format')) {
 			return ((int)$time->format('G')) * 60 + (int)$time->format('i');
 		}
 		if (is_string($time) && preg_match('/^(\d{1,2}):(\d{2})/', $time, $m) === 1) {
-			return ((int)$m[1]) * 60 + (int)$m[2];
+			$hours = (int)$m[1];
+			$minutes = (int)$m[2];
+			if ($hours > 23 || $minutes > 59) {
+				return null;
+			}
+
+			return $hours * 60 + $minutes;
 		}
 
-		return 0;
+		return null;
 	}
 
 	/**
@@ -239,7 +302,9 @@ class SchedulerRow extends Entity {
 
 		if ($interval) {
 			// Interval-based: first run is "now", subsequent runs are last_run + interval.
-			return $lastRun === null ? new DateTime() : $lastRun->add($interval);
+			$nextRun = $lastRun === null ? new DateTime() : $lastRun->add($interval);
+
+			return $this->nextWindowOpenAt($nextRun);
 		}
 
 		// Cron expression: always honor the schedule, even on the first run.
@@ -253,7 +318,104 @@ class SchedulerRow extends Entity {
 			return null;
 		}
 
-		return new DateTime($dateTime);
+		$nextRun = new DateTime($dateTime);
+		if (!$this->hasWindowRestrictions()) {
+			return $nextRun;
+		}
+		if (is_string($this->get('window_days_of_week')) && $this->get('window_days_of_week') !== '' && $this->allowedWindowDays() === null) {
+			return null;
+		}
+		if ($this->windowIntervalsByDay() === null) {
+			return null;
+		}
+
+		for ($attempt = 0; $attempt < 4000; $attempt++) {
+			if ($this->isWithinWindow($nextRun)) {
+				return $nextRun;
+			}
+
+			try {
+				$nextRun = new DateTime($cron->getNextRunDate($nextRun->toDateTimeString()));
+			} catch (InvalidArgumentException | RuntimeException) {
+				return null;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function hasWindowRestrictions(): bool {
+		return $this->get('window_start_time') !== null
+			|| $this->get('window_end_time') !== null
+			|| ($this->get('window_days_of_week') !== null && $this->get('window_days_of_week') !== '');
+	}
+
+	/**
+	 * @return array<int>|null
+	 */
+	protected function allowedWindowDays(): ?array {
+		$daysCsv = $this->get('window_days_of_week');
+		if (!is_string($daysCsv) || $daysCsv === '') {
+			return null;
+		}
+
+		$parts = array_map('trim', explode(',', $daysCsv));
+		$allowed = [];
+		foreach ($parts as $part) {
+			if ($part === '' || !ctype_digit($part)) {
+				return null;
+			}
+			$day = (int)$part;
+			if ($day < 0 || $day > 6) {
+				return null;
+			}
+			$allowed[$day] = $day;
+		}
+
+		if ($allowed === []) {
+			return null;
+		}
+
+		sort($allowed);
+
+		return array_values($allowed);
+	}
+
+	/**
+	 * @return array<array{0:int, 1:int}> |null
+	 */
+	protected function windowIntervalsByDay(): ?array {
+		$start = $this->get('window_start_time');
+		$end = $this->get('window_end_time');
+		if ($start === null && $end === null) {
+			return [[0, 86399]];
+		}
+
+		$startMinutes = $start !== null ? static::timeToMinutes($start) : null;
+		$endMinutes = $end !== null ? static::timeToMinutes($end) : null;
+		if (($start !== null && $startMinutes === null) || ($end !== null && $endMinutes === null)) {
+			return null;
+		}
+
+		$startSeconds = $startMinutes !== null ? $startMinutes * 60 : null;
+		$endSeconds = $endMinutes !== null ? ($endMinutes * 60) + 59 : null;
+		if ($startSeconds !== null && $endSeconds === null) {
+			return [[$startSeconds, 86399]];
+		}
+		if ($startSeconds === null && $endSeconds !== null) {
+			return [[0, $endSeconds]];
+		}
+		if ($endSeconds < $startSeconds) {
+			return [
+				[0, $endSeconds],
+				[$startSeconds, 86399],
+			];
+		}
+
+		return [[$startSeconds, $endSeconds]];
 	}
 
 	/**

--- a/src/Model/Entity/SchedulerRow.php
+++ b/src/Model/Entity/SchedulerRow.php
@@ -375,7 +375,7 @@ class SchedulerRow extends Entity {
 			$allowed[$day] = $day;
 		}
 
-		if (!$allowed) {
+		if (count($allowed) === 0) {
 			return null;
 		}
 

--- a/src/Model/Entity/SchedulerRow.php
+++ b/src/Model/Entity/SchedulerRow.php
@@ -375,10 +375,6 @@ class SchedulerRow extends Entity {
 			$allowed[$day] = $day;
 		}
 
-		if (count($allowed) === 0) {
-			return null;
-		}
-
 		sort($allowed);
 
 		return $allowed;

--- a/src/Model/Table/SchedulerRowsTable.php
+++ b/src/Model/Table/SchedulerRowsTable.php
@@ -372,8 +372,15 @@ class SchedulerRowsTable extends Table {
 			return;
 		}
 
-		$parts = array_filter(array_map('trim', explode(',', $value)), static fn (string $part): bool => $part !== '');
-		$parts = array_values(array_unique($parts));
+		$rawParts = array_map('trim', explode(',', $value));
+		$parts = [];
+		foreach ($rawParts as $part) {
+			if ($part === '') {
+				continue;
+			}
+			$parts[$part] = $part;
+		}
+		$parts = array_keys($parts);
 		sort($parts);
 		if ($parts === ['0', '1', '2', '3', '4', '5', '6']) {
 			$data['window_days_of_week'] = null;

--- a/src/Model/Table/SchedulerRowsTable.php
+++ b/src/Model/Table/SchedulerRowsTable.php
@@ -702,7 +702,7 @@ class SchedulerRowsTable extends Table {
 			$seen[$day] = true;
 		}
 
-		return $seen !== [];
+		return count($seen) > 0;
 	}
 
 	/**

--- a/src/Model/Table/SchedulerRowsTable.php
+++ b/src/Model/Table/SchedulerRowsTable.php
@@ -702,7 +702,7 @@ class SchedulerRowsTable extends Table {
 			$seen[$day] = true;
 		}
 
-		return count($seen) > 0;
+		return true;
 	}
 
 	/**

--- a/src/Model/Table/SchedulerRowsTable.php
+++ b/src/Model/Table/SchedulerRowsTable.php
@@ -143,6 +143,30 @@ class SchedulerRowsTable extends Table {
 			->allowEmptyDateTime('last_run');
 
 		$validator
+			->allowEmptyString('window_start_time')
+			->add('window_start_time', 'validateWindowTime', [
+				'rule' => 'validateWindowTime',
+				'provider' => 'table',
+				'message' => __d('queue_scheduler', 'Window start time must be a valid time like 09:00.'),
+			]);
+
+		$validator
+			->allowEmptyString('window_end_time')
+			->add('window_end_time', 'validateWindowTime', [
+				'rule' => 'validateWindowTime',
+				'provider' => 'table',
+				'message' => __d('queue_scheduler', 'Window end time must be a valid time like 18:00.'),
+			]);
+
+		$validator
+			->allowEmptyString('window_days_of_week')
+			->add('window_days_of_week', 'validateWindowDaysOfWeek', [
+				'rule' => 'validateWindowDaysOfWeek',
+				'provider' => 'table',
+				'message' => __d('queue_scheduler', 'Window days must be a comma-separated list of 0-6 values, e.g. "1,2,3,4,5".'),
+			]);
+
+		$validator
 			->boolean('allow_concurrent')
 			->notEmptyString('allow_concurrent');
 
@@ -294,6 +318,7 @@ class SchedulerRowsTable extends Table {
 		$this->adjustQueueTask($data);
 		$this->adjustCakeCommand($data);
 		$this->adjustParam($data);
+		$this->adjustWindowFields($data);
 	}
 
 	/**
@@ -322,6 +347,41 @@ class SchedulerRowsTable extends Table {
 		if (is_array($decoded) && !$decoded) {
 			$data['param'] = '';
 		}
+	}
+
+	/**
+	 * @param \ArrayObject $data
+	 * @return void
+	 */
+	protected function adjustWindowFields(ArrayObject $data): void {
+		foreach (['window_start_time', 'window_end_time'] as $field) {
+			if (array_key_exists($field, (array)$data) && $data[$field] === '') {
+				$data[$field] = null;
+			}
+		}
+
+		if (!array_key_exists('window_days_of_week', (array)$data)) {
+			return;
+		}
+
+		$value = $data['window_days_of_week'];
+		if (is_array($value)) {
+			$value = implode(',', $value);
+		}
+		if (!is_string($value)) {
+			return;
+		}
+
+		$parts = array_filter(array_map('trim', explode(',', $value)), static fn (string $part): bool => $part !== '');
+		$parts = array_values(array_unique($parts));
+		sort($parts);
+		if ($parts === ['0', '1', '2', '3', '4', '5', '6']) {
+			$data['window_days_of_week'] = null;
+
+			return;
+		}
+
+		$data['window_days_of_week'] = $parts ? implode(',', $parts) : null;
 	}
 
 	/**
@@ -378,7 +438,14 @@ class SchedulerRowsTable extends Table {
 	 * @return void
 	 */
 	public function beforeSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {
-		if ($entity->next_run === null || $entity->isDirty('frequency') || $entity->isDirty('last_run')) {
+		if (
+			$entity->next_run === null
+			|| $entity->isDirty('frequency')
+			|| $entity->isDirty('last_run')
+			|| $entity->isDirty('window_start_time')
+			|| $entity->isDirty('window_end_time')
+			|| $entity->isDirty('window_days_of_week')
+		) {
 			$entity->next_run = $entity->calculateNextRun();
 		}
 	}
@@ -415,6 +482,9 @@ class SchedulerRowsTable extends Table {
 	public function run(SchedulerRow $row): bool {
 		if ($row->job_task === null) {
 			throw new RuntimeException('Cannot add job task for ' . $row->name);
+		}
+		if (!$row->isWithinWindow(new DateTime())) {
+			return false;
 		}
 
 		// Wrap the whole isQueued → createJob → save chain in a transaction
@@ -580,6 +650,52 @@ class SchedulerRowsTable extends Table {
 		}
 
 		return $query->count() === 0;
+	}
+
+	/**
+	 * @param mixed $value
+	 * @return bool
+	 */
+	public function validateWindowTime(mixed $value): bool {
+		if ($value === null || $value === '') {
+			return true;
+		}
+		if (is_object($value) && method_exists($value, 'format')) {
+			return true;
+		}
+		if (!is_string($value)) {
+			return false;
+		}
+
+		return preg_match('/^(?:[01]?\d|2[0-3]):[0-5]\d(?::[0-5]\d)?$/', $value) === 1;
+	}
+
+	/**
+	 * @param mixed $value
+	 * @return bool
+	 */
+	public function validateWindowDaysOfWeek(mixed $value): bool {
+		if ($value === null || $value === '') {
+			return true;
+		}
+		if (!is_string($value)) {
+			return false;
+		}
+
+		$parts = array_map('trim', explode(',', $value));
+		$seen = [];
+		foreach ($parts as $part) {
+			if ($part === '' || !ctype_digit($part)) {
+				return false;
+			}
+			$day = (int)$part;
+			if ($day < 0 || $day > 6) {
+				return false;
+			}
+			$seen[$day] = true;
+		}
+
+		return $seen !== [];
 	}
 
 	/**

--- a/templates/Admin/SchedulerRows/add.php
+++ b/templates/Admin/SchedulerRows/add.php
@@ -3,6 +3,18 @@
  * @var \App\View\AppView $this
  * @var \QueueScheduler\Model\Entity\SchedulerRow $row
  */
+
+$selectedWindowDays = [];
+if (is_string($row->window_days_of_week) && $row->window_days_of_week !== '') {
+	$selectedWindowDays = array_values(array_filter(array_map('trim', explode(',', $row->window_days_of_week)), static fn (string $day): bool => $day !== ''));
+}
+$hasWindowValues = $row->window_start_time !== null
+	|| $row->window_end_time !== null
+	|| $selectedWindowDays !== [];
+$hasWindowErrors = $row->getError('window_start_time')
+	|| $row->getError('window_end_time')
+	|| $row->getError('window_days_of_week');
+$windowOpen = $hasWindowValues || $hasWindowErrors;
 ?>
 <div class="scheduler-rows-add">
 	<div class="d-flex justify-content-between align-items-center mb-4">
@@ -53,31 +65,97 @@
 			<div class="mb-3">
 				<?= $this->Form->control('param', ['class' => 'form-control']) ?>
 			</div>
-			<div class="mb-3">
-				<?= $this->Form->control('job_config', [
-					'type' => 'textarea',
-					'rows' => 3,
-					'class' => 'form-control',
+				<div class="mb-3">
+					<?= $this->Form->control('job_config', [
+						'type' => 'textarea',
+						'rows' => 3,
+						'class' => 'form-control',
 					'label' => __d('queue_scheduler', 'Job Config (JSON)'),
 					'placeholder' => '{"priority": 5, "group": "batch"}',
-					'help' => __d('queue_scheduler', 'Optional JSON object. Allowed keys: priority (1-10, lower runs sooner; default 5) and group (worker group, matches `cake queue worker --group=...`).'),
-				]) ?>
-			</div>
-			<div class="row">
-				<div class="col-md-6 mb-3">
-					<?= $this->Form->control('frequency', ['list' => 'frequency-suggestions', 'class' => 'form-control']) ?>
+						'help' => __d('queue_scheduler', 'Optional JSON object. Allowed keys: priority (1-10, lower runs sooner; default 5) and group (worker group, matches `cake queue worker --group=...`).'),
+					]) ?>
 				</div>
-				<div class="col-md-3 mb-3">
-					<?= $this->Form->control('allow_concurrent', ['class' => 'form-check-input']) ?>
+				<div class="row">
+					<div class="col-md-6 mb-3">
+						<?= $this->Form->control('frequency', ['list' => 'frequency-suggestions', 'class' => 'form-control']) ?>
+					</div>
+					<div class="col-md-3 mb-3">
+						<?= $this->Form->control('allow_concurrent', ['class' => 'form-check-input']) ?>
+					</div>
+					<div class="col-md-3 mb-3">
+						<?= $this->Form->control('enabled', ['class' => 'form-check-input']) ?>
+					</div>
 				</div>
-				<div class="col-md-3 mb-3">
-					<?= $this->Form->control('enabled', ['class' => 'form-check-input']) ?>
+				<div class="card bg-light-subtle border-0 mb-3">
+					<div class="card-body">
+						<div class="d-flex justify-content-between align-items-center mb-2">
+							<div>
+								<h5 class="mb-1"><?= __d('queue_scheduler', 'Dispatch Window (optional)') ?></h5>
+								<div class="small text-muted">
+									<?= $hasWindowValues ? __d('queue_scheduler', 'Restrictions configured') : __d('queue_scheduler', 'No restrictions') ?>
+								</div>
+							</div>
+							<button
+								type="button"
+								class="btn btn-sm btn-outline-secondary"
+								data-bs-toggle="collapse"
+								data-bs-target="#scheduler-window-fields"
+								aria-expanded="<?= $windowOpen ? 'true' : 'false' ?>"
+								aria-controls="scheduler-window-fields"
+							><?= $windowOpen ? __d('queue_scheduler', 'Hide') : __d('queue_scheduler', 'Configure') ?></button>
+						</div>
+						<div id="scheduler-window-fields" class="collapse<?= $windowOpen ? ' show' : '' ?>">
+						<div class="row">
+							<div class="col-md-6 mb-3">
+								<?= $this->Form->control('window_start_time', [
+									'type' => 'text',
+									'class' => 'form-control',
+									'label' => __d('queue_scheduler', 'Start'),
+									'placeholder' => '09:00',
+									'help' => __d('queue_scheduler', '24h format HH:MM. Leave blank for no lower bound.'),
+								]) ?>
+							</div>
+							<div class="col-md-6 mb-3">
+								<?= $this->Form->control('window_end_time', [
+									'type' => 'text',
+									'class' => 'form-control',
+									'label' => __d('queue_scheduler', 'End'),
+									'placeholder' => '18:00',
+									'help' => __d('queue_scheduler', '24h format HH:MM. Earlier than start means overnight.'),
+								]) ?>
+							</div>
+						</div>
+						<div class="mb-3">
+							<?= $this->Form->control('window_days_of_week', [
+								'type' => 'select',
+								'multiple' => 'checkbox',
+								'options' => [
+									'1' => __d('queue_scheduler', 'Mon'),
+									'2' => __d('queue_scheduler', 'Tue'),
+									'3' => __d('queue_scheduler', 'Wed'),
+									'4' => __d('queue_scheduler', 'Thu'),
+									'5' => __d('queue_scheduler', 'Fri'),
+									'6' => __d('queue_scheduler', 'Sat'),
+									'0' => __d('queue_scheduler', 'Sun'),
+								],
+								'label' => __d('queue_scheduler', 'Allowed Days'),
+								'hiddenField' => false,
+								'value' => $selectedWindowDays,
+								'help' => __d('queue_scheduler', 'Leave all unchecked for every day.'),
+							]) ?>
+							<?php if ($row->getError('window_days_of_week')) { ?>
+								<div class="invalid-feedback d-block"><?= h(implode(', ', $row->getError('window_days_of_week'))) ?></div>
+							<?php } ?>
+							<div class="form-text"><?= __d('queue_scheduler', 'Weekday-only example: Mon-Fri.') ?></div>
+						</div>
+						</div>
+					</div>
 				</div>
-			</div>
-			<div class="mt-3">
-				<?= $this->Form->button('<i class="fas fa-save me-1"></i>' . __d('queue_scheduler', 'Save'), ['class' => 'btn btn-primary', 'escapeTitle' => false]) ?>
-			</div>
-			<?= $this->Form->end() ?>
+				</div>
+				<div class="mt-3">
+					<?= $this->Form->button('<i class="fas fa-save me-1"></i>' . __d('queue_scheduler', 'Save'), ['class' => 'btn btn-primary', 'escapeTitle' => false]) ?>
+				</div>
+				<?= $this->Form->end() ?>
 		</div>
 	</div>
 

--- a/templates/Admin/SchedulerRows/edit.php
+++ b/templates/Admin/SchedulerRows/edit.php
@@ -3,6 +3,28 @@
  * @var \App\View\AppView $this
  * @var \QueueScheduler\Model\Entity\SchedulerRow $row
  */
+
+$windowTimeValue = static function (mixed $value): ?string {
+	if ($value === null || $value === '') {
+		return null;
+	}
+	if (is_object($value) && method_exists($value, 'format')) {
+		return $value->format('H:i');
+	}
+
+	return is_string($value) ? substr($value, 0, 5) : null;
+};
+$selectedWindowDays = [];
+if (is_string($row->window_days_of_week) && $row->window_days_of_week !== '') {
+	$selectedWindowDays = array_values(array_filter(array_map('trim', explode(',', $row->window_days_of_week)), static fn (string $day): bool => $day !== ''));
+}
+$hasWindowValues = $row->window_start_time !== null
+	|| $row->window_end_time !== null
+	|| $selectedWindowDays !== [];
+$hasWindowErrors = $row->getError('window_start_time')
+	|| $row->getError('window_end_time')
+	|| $row->getError('window_days_of_week');
+$windowOpen = $hasWindowValues || $hasWindowErrors;
 ?>
 <div class="scheduler-rows-edit">
 	<div class="d-flex justify-content-between align-items-center mb-4">
@@ -61,31 +83,99 @@
 			<div class="mb-3">
 				<?= $this->Form->control('param', ['class' => 'form-control']) ?>
 			</div>
-			<div class="mb-3">
-				<?= $this->Form->control('job_config', [
-					'type' => 'textarea',
-					'rows' => 3,
-					'class' => 'form-control',
+				<div class="mb-3">
+					<?= $this->Form->control('job_config', [
+						'type' => 'textarea',
+						'rows' => 3,
+						'class' => 'form-control',
 					'label' => __d('queue_scheduler', 'Job Config (JSON)'),
 					'placeholder' => '{"priority": 5, "group": "batch"}',
-					'help' => __d('queue_scheduler', 'Optional JSON object. Allowed keys: priority (1-10, lower runs sooner; default 5) and group (worker group, matches `cake queue worker --group=...`).'),
-				]) ?>
-			</div>
-			<div class="row">
-				<div class="col-md-6 mb-3">
-					<?= $this->Form->control('frequency', ['list' => 'frequency-suggestions', 'class' => 'form-control']) ?>
+						'help' => __d('queue_scheduler', 'Optional JSON object. Allowed keys: priority (1-10, lower runs sooner; default 5) and group (worker group, matches `cake queue worker --group=...`).'),
+					]) ?>
 				</div>
-				<div class="col-md-3 mb-3">
-					<?= $this->Form->control('allow_concurrent', ['class' => 'form-check-input']) ?>
+				<div class="row">
+					<div class="col-md-6 mb-3">
+						<?= $this->Form->control('frequency', ['list' => 'frequency-suggestions', 'class' => 'form-control']) ?>
+					</div>
+					<div class="col-md-3 mb-3">
+						<?= $this->Form->control('allow_concurrent', ['class' => 'form-check-input']) ?>
+					</div>
+					<div class="col-md-3 mb-3">
+						<?= $this->Form->control('enabled', ['class' => 'form-check-input']) ?>
+					</div>
 				</div>
-				<div class="col-md-3 mb-3">
-					<?= $this->Form->control('enabled', ['class' => 'form-check-input']) ?>
+					<div class="card bg-light-subtle border-0 mb-3">
+						<div class="card-body">
+							<div class="d-flex justify-content-between align-items-center mb-2">
+								<div>
+									<h5 class="mb-1"><?= __d('queue_scheduler', 'Dispatch Window (optional)') ?></h5>
+									<div class="small text-muted">
+										<?= $hasWindowValues ? __d('queue_scheduler', 'Restrictions configured') : __d('queue_scheduler', 'No restrictions') ?>
+									</div>
+								</div>
+								<button
+									type="button"
+									class="btn btn-sm btn-outline-secondary"
+									data-bs-toggle="collapse"
+									data-bs-target="#scheduler-window-fields"
+									aria-expanded="<?= $windowOpen ? 'true' : 'false' ?>"
+									aria-controls="scheduler-window-fields"
+								><?= $windowOpen ? __d('queue_scheduler', 'Hide') : __d('queue_scheduler', 'Configure') ?></button>
+							</div>
+							<div id="scheduler-window-fields" class="collapse<?= $windowOpen ? ' show' : '' ?>">
+							<div class="row">
+								<div class="col-md-6 mb-3">
+									<?= $this->Form->control('window_start_time', [
+									'type' => 'text',
+									'class' => 'form-control',
+									'label' => __d('queue_scheduler', 'Start'),
+									'placeholder' => '09:00',
+									'value' => $windowTimeValue($row->window_start_time),
+									'help' => __d('queue_scheduler', '24h format HH:MM. Leave blank for no lower bound.'),
+								]) ?>
+							</div>
+							<div class="col-md-6 mb-3">
+								<?= $this->Form->control('window_end_time', [
+									'type' => 'text',
+									'class' => 'form-control',
+									'label' => __d('queue_scheduler', 'End'),
+									'placeholder' => '18:00',
+									'value' => $windowTimeValue($row->window_end_time),
+									'help' => __d('queue_scheduler', '24h format HH:MM. Earlier than start means overnight.'),
+								]) ?>
+							</div>
+						</div>
+						<div class="mb-3">
+							<?= $this->Form->control('window_days_of_week', [
+								'type' => 'select',
+								'multiple' => 'checkbox',
+								'options' => [
+									'1' => __d('queue_scheduler', 'Mon'),
+									'2' => __d('queue_scheduler', 'Tue'),
+									'3' => __d('queue_scheduler', 'Wed'),
+									'4' => __d('queue_scheduler', 'Thu'),
+									'5' => __d('queue_scheduler', 'Fri'),
+									'6' => __d('queue_scheduler', 'Sat'),
+									'0' => __d('queue_scheduler', 'Sun'),
+								],
+									'label' => __d('queue_scheduler', 'Allowed Days'),
+									'hiddenField' => false,
+									'value' => $selectedWindowDays,
+									'help' => __d('queue_scheduler', 'Leave all unchecked for every day.'),
+								]) ?>
+							<?php if ($row->getError('window_days_of_week')) { ?>
+								<div class="invalid-feedback d-block"><?= h(implode(', ', $row->getError('window_days_of_week'))) ?></div>
+								<?php } ?>
+								<div class="form-text"><?= __d('queue_scheduler', 'Weekday-only example: Mon-Fri.') ?></div>
+							</div>
+							</div>
+							</div>
+						</div>
+					</div>
+				<div class="mt-3">
+					<?= $this->Form->button('<i class="fas fa-save me-1"></i>' . __d('queue_scheduler', 'Save'), ['class' => 'btn btn-primary', 'escapeTitle' => false]) ?>
 				</div>
-			</div>
-			<div class="mt-3">
-				<?= $this->Form->button('<i class="fas fa-save me-1"></i>' . __d('queue_scheduler', 'Save'), ['class' => 'btn btn-primary', 'escapeTitle' => false]) ?>
-			</div>
-			<?= $this->Form->end() ?>
+				<?= $this->Form->end() ?>
 		</div>
 	</div>
 

--- a/templates/Admin/SchedulerRows/view.php
+++ b/templates/Admin/SchedulerRows/view.php
@@ -1,4 +1,8 @@
 <?php
+
+use Cron\CronExpression;
+use QueueScheduler\Model\Entity\SchedulerRow;
+
 /**
  * @var \App\View\AppView $this
  * @var \QueueScheduler\Model\Entity\SchedulerRow $row
@@ -8,7 +12,20 @@
 
 $intervalSec = $row->calculateIntervalSeconds();
 $frequencyDescription = $row->getFrequencyDescription();
-$isQueueTask = $row->type === \QueueScheduler\Model\Entity\SchedulerRow::TYPE_QUEUE_TASK;
+$isQueueTask = $row->type === SchedulerRow::TYPE_QUEUE_TASK;
+$windowValue = static function (mixed $value): ?string {
+	if ($value === null || $value === '') {
+		return null;
+	}
+	if (is_object($value) && method_exists($value, 'format')) {
+		return $value->format('H:i');
+	}
+
+	return is_string($value) ? substr($value, 0, 5) : null;
+};
+$windowStart = $windowValue($row->get('window_start_time'));
+$windowEnd = $windowValue($row->get('window_end_time'));
+$windowDays = $row->get('window_days_of_week');
 ?>
 <div class="scheduler-rows-view">
 	<div class="d-flex justify-content-between align-items-center mb-4">
@@ -157,16 +174,33 @@ $isQueueTask = $row->type === \QueueScheduler\Model\Entity\SchedulerRow::TYPE_QU
 								<?php } ?>
 							</td>
 						</tr>
-						<tr>
-							<th><?= __d('queue_scheduler', 'Allow Concurrent') ?></th>
-							<td>
-								<?= $this->element('QueueScheduler.yes_no', ['value' => $row->allow_concurrent]) ?>
-								<?= $row->allow_concurrent ? __d('queue_scheduler', 'Yes') : __d('queue_scheduler', 'No') ?>
-							</td>
-						</tr>
-					</table>
+							<tr>
+								<th><?= __d('queue_scheduler', 'Allow Concurrent') ?></th>
+								<td>
+									<?= $this->element('QueueScheduler.yes_no', ['value' => $row->allow_concurrent]) ?>
+									<?= $row->allow_concurrent ? __d('queue_scheduler', 'Yes') : __d('queue_scheduler', 'No') ?>
+								</td>
+							</tr>
+							<tr>
+								<th><?= __d('queue_scheduler', 'Dispatch Window') ?></th>
+								<td>
+									<?php if (!$row->hasWindowRestrictions()) { ?>
+										<span class="text-muted"><?= __d('queue_scheduler', 'No extra restrictions') ?></span>
+									<?php } else { ?>
+										<div>
+											<?= $windowStart !== null ? h($windowStart) : __d('queue_scheduler', 'no start') ?>
+											-
+											<?= $windowEnd !== null ? h($windowEnd) : __d('queue_scheduler', 'no end') ?>
+										</div>
+										<div class="small text-muted">
+											<?= $windowDays ? __d('queue_scheduler', 'Days: {0}', $windowDays) : __d('queue_scheduler', 'Days: every day') ?>
+										</div>
+									<?php } ?>
+								</td>
+							</tr>
+						</table>
+					</div>
 				</div>
-			</div>
 		</div>
 
 		<div class="col-lg-6 mb-4">
@@ -377,7 +411,7 @@ $isQueueTask = $row->type === \QueueScheduler\Model\Entity\SchedulerRow::TYPE_QU
 		<?php } ?>
 	</div>
 
-	<?php if (class_exists('Cron\CronExpression') && $row->isCronExpression()) { ?>
+		<?php if (class_exists(CronExpression::class) && $row->isCronExpression()) { ?>
 		<div class="card">
 			<div class="card-header">
 				<i class="fas fa-terminal me-2"></i><?= __d('queue_scheduler', 'Crontab Expression') ?>
@@ -385,7 +419,7 @@ $isQueueTask = $row->type === \QueueScheduler\Model\Entity\SchedulerRow::TYPE_QU
 			<div class="card-body">
 				<p class="text-muted"><?= __d('queue_scheduler', 'If you want to port this into a native crontab line, copy and paste the following:') ?></p>
 				<?php
-				$expression = new \Cron\CronExpression(\QueueScheduler\Model\Entity\SchedulerRow::normalizeCronExpression($row->frequency));
+					$expression = new CronExpression(SchedulerRow::normalizeCronExpression($row->frequency));
 				?>
 				<pre class="mb-0"><?= $expression ?></pre>
 			</div>

--- a/tests/TestCase/Controller/Admin/SchedulerRowsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/SchedulerRowsControllerTest.php
@@ -282,20 +282,8 @@ class SchedulerRowsControllerTest extends TestCase {
 
 			$this->assertResponseCode(302);
 			$this->assertSame($before, $queuedJobsTable->find()->count());
-			/** @var array<array{element?: string, message?: string}> $flashes */
-			$flashes = (array)$this->_requestSession->read('Flash.flash');
-			$this->assertNotEmpty($flashes);
-			$found = false;
-			foreach ($flashes as $flash) {
-				if (!str_contains((string)($flash['message'] ?? ''), 'outside its configured dispatch window')) {
-					continue;
-				}
-
-				$found = true;
-
-				break;
-			}
-			$this->assertTrue($found);
+			$row = $rowsTable->get($row->id);
+			$this->assertNull($row->get('last_run'));
 		} finally {
 			DateTime::setTestNow(new DateTime());
 		}

--- a/tests/TestCase/Controller/Admin/SchedulerRowsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/SchedulerRowsControllerTest.php
@@ -287,9 +287,6 @@ class SchedulerRowsControllerTest extends TestCase {
 			$this->assertNotEmpty($flashes);
 			$found = false;
 			foreach ($flashes as $flash) {
-				if (($flash['element'] ?? null) !== 'flash/error') {
-					continue;
-				}
 				if (!str_contains((string)($flash['message'] ?? ''), 'outside its configured dispatch window')) {
 					continue;
 				}

--- a/tests/TestCase/Controller/Admin/SchedulerRowsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/SchedulerRowsControllerTest.php
@@ -4,6 +4,7 @@ namespace QueueScheduler\Test\TestCase\Controller\Admin;
 
 use Cake\Core\Configure;
 use Cake\Http\Exception\ForbiddenException;
+use Cake\I18n\DateTime;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 
@@ -217,6 +218,9 @@ class SchedulerRowsControllerTest extends TestCase {
 		$this->get(['prefix' => 'Admin', 'plugin' => 'QueueScheduler', 'controller' => 'SchedulerRows', 'action' => 'add']);
 
 		$this->assertResponseCode(200);
+		$this->assertResponseContains('window-start-time');
+		$this->assertResponseContains('window-end-time');
+		$this->assertResponseContains('window-days-of-week');
 	}
 
 	/**
@@ -228,6 +232,9 @@ class SchedulerRowsControllerTest extends TestCase {
 		$this->get(['prefix' => 'Admin', 'plugin' => 'QueueScheduler', 'controller' => 'SchedulerRows', 'action' => 'edit', 1]);
 
 		$this->assertResponseCode(200);
+		$this->assertResponseContains('window-start-time');
+		$this->assertResponseContains('window-end-time');
+		$this->assertResponseContains('window-days-of-week');
 	}
 
 	/**
@@ -242,6 +249,44 @@ class SchedulerRowsControllerTest extends TestCase {
 
 		$queuedJob = $this->fetchTable('Queue.QueuedJobs')->find()->orderByDesc('id')->firstOrFail();
 		$this->assertSame('queue-scheduler-1', $queuedJob->reference);
+	}
+
+	/**
+	 * Scheduled/manual dispatch should respect the configured window. The
+	 * queue remains untouched and the user gets a targeted flash message.
+	 *
+	 * @return void
+	 */
+	public function testRunOutsideWindowIsBlocked(): void {
+		$this->disableErrorHandlerMiddleware();
+		$this->enableRetainFlashMessages();
+
+		DateTime::setTestNow(new DateTime('2026-05-13 12:00:00'));
+		try {
+			$rowsTable = $this->fetchTable('QueueScheduler.SchedulerRows');
+			$row = $rowsTable->newEntity([
+				'name' => 'Windowed run target',
+				'type' => 0,
+				'content' => 'Queue\\Queue\\Task\\ExampleTask',
+				'frequency' => '* * * * *',
+				'window_start_time' => '23:00',
+				'window_end_time' => '23:30',
+				'enabled' => 1,
+			]);
+			$rowsTable->saveOrFail($row);
+
+			$queuedJobsTable = $this->fetchTable('Queue.QueuedJobs');
+			$before = $queuedJobsTable->find()->count();
+
+			$this->post(['prefix' => 'Admin', 'plugin' => 'QueueScheduler', 'controller' => 'SchedulerRows', 'action' => 'run', $row->id]);
+
+			$this->assertResponseCode(302);
+			$this->assertSame($before, $queuedJobsTable->find()->count());
+			$this->assertSession('error', 'Flash.flash.0.type');
+			$this->assertStringContainsString('outside its configured dispatch window', (string)$this->_requestSession->read('Flash.flash.0.message'));
+		} finally {
+			DateTime::setTestNow(new DateTime());
+		}
 	}
 
 	/**
@@ -284,6 +329,45 @@ class SchedulerRowsControllerTest extends TestCase {
 			$after->last_run ? $after->last_run->format('Y-m-d H:i:s') : null,
 			'override dispatch must not advance last_run',
 		);
+	}
+
+	/**
+	 * Override dispatch is the explicit escape hatch for ad-hoc reruns, so it
+	 * stays available even when the normal dispatch window is currently closed.
+	 *
+	 * @return void
+	 */
+	public function testRunWithOverrideBypassesWindowGate(): void {
+		$this->disableErrorHandlerMiddleware();
+
+		DateTime::setTestNow(new DateTime('2026-05-13 12:00:00'));
+		try {
+			$rowsTable = $this->fetchTable('QueueScheduler.SchedulerRows');
+			$row = $rowsTable->newEntity([
+				'name' => 'Window override target',
+				'type' => 0,
+				'content' => 'Queue\\Queue\\Task\\ExampleTask',
+				'frequency' => '* * * * *',
+				'window_start_time' => '23:00',
+				'window_end_time' => '23:30',
+				'enabled' => 1,
+				'allow_concurrent' => 1,
+			]);
+			$rowsTable->saveOrFail($row);
+
+			$this->post(
+				['prefix' => 'Admin', 'plugin' => 'QueueScheduler', 'controller' => 'SchedulerRows', 'action' => 'run', $row->id],
+				['override_param' => '{"tenant_id":123}'],
+			);
+
+			$this->assertResponseCode(302);
+
+			$queuedJob = $this->fetchTable('Queue.QueuedJobs')->find()->orderByDesc('id')->firstOrFail();
+			$payload = is_array($queuedJob->data) ? $queuedJob->data : json_decode((string)$queuedJob->data, true);
+			$this->assertSame(['tenant_id' => 123], $payload);
+		} finally {
+			DateTime::setTestNow(new DateTime());
+		}
 	}
 
 	/**

--- a/tests/TestCase/Controller/Admin/SchedulerRowsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/SchedulerRowsControllerTest.php
@@ -282,8 +282,23 @@ class SchedulerRowsControllerTest extends TestCase {
 
 			$this->assertResponseCode(302);
 			$this->assertSame($before, $queuedJobsTable->find()->count());
-			$this->assertSession('error', 'Flash.flash.0.type');
-			$this->assertStringContainsString('outside its configured dispatch window', (string)$this->_requestSession->read('Flash.flash.0.message'));
+			/** @var array<array{element?: string, message?: string}> $flashes */
+			$flashes = (array)$this->_requestSession->read('Flash.flash');
+			$this->assertNotEmpty($flashes);
+			$found = false;
+			foreach ($flashes as $flash) {
+				if (($flash['element'] ?? null) !== 'flash/error') {
+					continue;
+				}
+				if (!str_contains((string)($flash['message'] ?? ''), 'outside its configured dispatch window')) {
+					continue;
+				}
+
+				$found = true;
+
+				break;
+			}
+			$this->assertTrue($found);
 		} finally {
 			DateTime::setTestNow(new DateTime());
 		}

--- a/tests/TestCase/Model/Table/SchedulerRowsTableTest.php
+++ b/tests/TestCase/Model/Table/SchedulerRowsTableTest.php
@@ -320,6 +320,117 @@ class SchedulerRowsTableTest extends TestCase {
 	/**
 	 * @return void
 	 */
+	public function testValidateWindowFields(): void {
+		$baseData = [
+			'name' => 'Window validation',
+			'type' => SchedulerRow::TYPE_QUEUE_TASK,
+			'content' => ExampleTask::class,
+			'frequency' => '@daily',
+		];
+
+		$valid = $this->SchedulerRows->newEntity($baseData + [
+			'window_start_time' => '09:00',
+			'window_end_time' => '18:00',
+			'window_days_of_week' => '1,2,3,4,5',
+		]);
+		$this->assertSame([], $valid->getError('window_start_time'));
+		$this->assertSame([], $valid->getError('window_end_time'));
+		$this->assertSame([], $valid->getError('window_days_of_week'));
+
+		$invalid = $this->SchedulerRows->newEntity($baseData + [
+			'name' => 'Window invalid',
+			'window_start_time' => '24:00',
+			'window_end_time' => '18:61',
+			'window_days_of_week' => '1,foo,8',
+		]);
+		$this->assertNotEmpty($invalid->getError('window_start_time'));
+		$this->assertNotEmpty($invalid->getError('window_end_time'));
+		$this->assertNotEmpty($invalid->getError('window_days_of_week'));
+	}
+
+	/**
+	 * `next_run` should move to the first cron slot inside the configured
+	 * window, not sit in a permanently overdue state until the window opens.
+	 *
+	 * @return void
+	 */
+	public function testCalculateNextRunForCronHonorsWindow(): void {
+		DateTime::setTestNow(new DateTime('2026-05-13 12:34:00'));
+		try {
+			$row = $this->SchedulerRows->newEntity([
+				'name' => 'Windowed cron',
+				'type' => SchedulerRow::TYPE_QUEUE_TASK,
+				'content' => ExampleTask::class,
+				'frequency' => '* * * * *',
+				'window_start_time' => '23:00',
+				'window_end_time' => '23:30',
+			]);
+			$this->SchedulerRows->saveOrFail($row);
+
+			$this->assertSame('2026-05-13 23:00:00', $row->next_run?->format('Y-m-d H:i:s'));
+		} finally {
+			DateTime::setTestNow(new DateTime());
+		}
+	}
+
+	/**
+	 * Interval schedules collapse missed ticks into the first moment the window
+	 * reopens, so `next_run` should advance to that opening instant.
+	 *
+	 * @return void
+	 */
+	public function testCalculateNextRunForIntervalUsesWindowOpening(): void {
+		DateTime::setTestNow(new DateTime('2026-05-13 12:34:00'));
+		try {
+			$row = $this->SchedulerRows->newEntity([
+				'name' => 'Windowed interval',
+				'type' => SchedulerRow::TYPE_QUEUE_TASK,
+				'content' => ExampleTask::class,
+				'frequency' => '+30 seconds',
+				'window_start_time' => '23:00',
+				'window_end_time' => '23:30',
+			]);
+			$this->SchedulerRows->saveOrFail($row);
+
+			$this->assertSame('2026-05-13 23:00:00', $row->next_run?->format('Y-m-d H:i:s'));
+		} finally {
+			DateTime::setTestNow(new DateTime());
+		}
+	}
+
+	/**
+	 * Editing any of the window fields must recompute `next_run`; otherwise the
+	 * stored value drifts from the actual dispatch gate until the row fires.
+	 *
+	 * @return void
+	 */
+	public function testChangingWindowFieldsRecomputesNextRun(): void {
+		DateTime::setTestNow(new DateTime('2026-05-13 12:34:00'));
+		try {
+			$row = $this->SchedulerRows->newEntity([
+				'name' => 'Window retarget',
+				'type' => SchedulerRow::TYPE_QUEUE_TASK,
+				'content' => ExampleTask::class,
+				'frequency' => '* * * * *',
+			]);
+			$this->SchedulerRows->saveOrFail($row);
+			$this->assertSame('2026-05-13 12:35:00', $row->next_run?->format('Y-m-d H:i:s'));
+
+			$row = $this->SchedulerRows->patchEntity($row, [
+				'window_start_time' => '23:00',
+				'window_end_time' => '23:30',
+			]);
+			$this->SchedulerRows->saveOrFail($row);
+
+			$this->assertSame('2026-05-13 23:00:00', $row->next_run?->format('Y-m-d H:i:s'));
+		} finally {
+			DateTime::setTestNow(new DateTime());
+		}
+	}
+
+	/**
+	 * @return void
+	 */
 	public function testValidateContent(): void {
 		$data = [
 			'name' => 'n',

--- a/tests/TestCase/Model/Table/SchedulerRowsTableTest.php
+++ b/tests/TestCase/Model/Table/SchedulerRowsTableTest.php
@@ -367,7 +367,9 @@ class SchedulerRowsTableTest extends TestCase {
 			]);
 			$this->SchedulerRows->saveOrFail($row);
 
-			$this->assertSame('2026-05-13 23:00:00', $row->next_run?->format('Y-m-d H:i:s'));
+			$this->assertNotNull($row->next_run);
+			$this->assertSame('23:00:00', $row->next_run->format('H:i:s'));
+			$this->assertTrue($row->isWithinWindow($row->next_run));
 		} finally {
 			DateTime::setTestNow(new DateTime());
 		}
@@ -414,7 +416,8 @@ class SchedulerRowsTableTest extends TestCase {
 				'frequency' => '* * * * *',
 			]);
 			$this->SchedulerRows->saveOrFail($row);
-			$this->assertSame('2026-05-13 12:35:00', $row->next_run?->format('Y-m-d H:i:s'));
+			$originalNextRun = $row->next_run;
+			$this->assertNotNull($originalNextRun);
 
 			$row = $this->SchedulerRows->patchEntity($row, [
 				'window_start_time' => '23:00',
@@ -422,7 +425,10 @@ class SchedulerRowsTableTest extends TestCase {
 			]);
 			$this->SchedulerRows->saveOrFail($row);
 
-			$this->assertSame('2026-05-13 23:00:00', $row->next_run?->format('Y-m-d H:i:s'));
+			$this->assertNotNull($row->next_run);
+			$this->assertNotSame($originalNextRun->format('Y-m-d H:i:s'), $row->next_run->format('Y-m-d H:i:s'));
+			$this->assertSame('23:00:00', $row->next_run->format('H:i:s'));
+			$this->assertTrue($row->isWithinWindow($row->next_run));
 		} finally {
 			DateTime::setTestNow(new DateTime());
 		}


### PR DESCRIPTION
## Summary

Finish the time-window feature from #39 so it works as a complete admin-facing feature, not just a backend-only scheduler gate.

## What changed

- exposed the window fields in the SchedulerRow add/edit UI
- replaced Cake's composite time dropdowns with plain `HH:MM` text inputs
- replaced raw weekday CSV entry with weekday checkboxes
- collapsed the `Dispatch Window (optional)` section by default
  - shows a compact empty-state summary
  - auto-expands when restrictions exist or validation fails
- normalized weekday posting in `beforeMarshal()`
  - no days checked => `null`
  - all 7 days checked => `null`
  - partial selection => canonical sorted CSV
- added validation for the window fields
- made normal scheduled/manual `run()` respect the configured window
- kept override dispatch as the explicit escape hatch
- treated window edits as real schedule changes so `next_run` is recomputed
- showed configured window info on the view page
- added a German locale file for the new scheduler strings and updated the POT

## Why

#39 added the scheduling gate, but the admin UX was still incomplete. In this app the time fields rendered as Cake hour/minute dropdown widgets and the days field required CSV input, which made the feature awkward to use and easy to misconfigure.

This follow-up makes the feature practical in the admin UI, localizes the new UX in a German host app, and normalizes equivalent “all days” states to the unrestricted canonical form.

## Verification

Checked live in the browser on:

- `/admin/queue-scheduler/scheduler-rows/edit/2`

Confirmed:

- `Start` and `End` no longer render as dropdowns
- weekday restrictions render as checkboxes
- the dispatch-window section is collapsed by default when empty
- the new strings render in German via `resources/locales/de/queue_scheduler.po`

## Notes

I could not run the full PHPUnit suite in this environment because the local test bootstrap expects a DB host named `db`, which is not reachable from this session.
