### PR TITLE
Fix flaky master: calculateNextRun must honor DateTime::setTestNow

### DIFF
--- a/src/Model/Entity/SchedulerRow.php
+++ b/src/Model/Entity/SchedulerRow.php
@@ -308,12 +308,15 @@ class SchedulerRow extends Entity {
 		}
 
 		// Cron expression: always honor the schedule, even on the first run.
+		// Pass Cake's test-aware "now" instead of letting CronExpression resolve
+		// "now" itself — its DateTimeImmutable('now') ignores DateTime::setTestNow,
+		// which makes window-aware tests flaky depending on wall-clock time.
 		// Catch the specific exception types declared by the cron-expression library
 		// (constructor throws InvalidArgumentException; getNextRunDate throws
 		// RuntimeException) so phpstan does not flag a broader catch as "dead".
 		try {
 			$cron = new CronExpression(static::normalizeCronExpression($this->frequency));
-			$dateTime = $cron->getNextRunDate();
+			$dateTime = $cron->getNextRunDate((new DateTime())->toDateTimeString());
 		} catch (InvalidArgumentException | RuntimeException $e) {
 			return null;
 		}

--- a/tests/TestCase/Model/Entity/SchedulerRowTest.php
+++ b/tests/TestCase/Model/Entity/SchedulerRowTest.php
@@ -444,16 +444,14 @@ class SchedulerRowTest extends TestCase {
 		]);
 
 		$nextRun = $row->calculateNextRun();
-		// CronExpression evaluates against real wall-clock time (not setTestNow),
-		// so we compare against time() rather than `new DateTime()` which respects
-		// the bootstrap-frozen Chronos::now().
-		$now = time();
+		$now = new DateTime();
 
 		$this->assertInstanceOf(DateTime::class, $nextRun);
 		// Result is on a minute boundary.
 		$this->assertSame(0, (int)$nextRun->format('s'));
-		// And within ~2 minutes of real now (covers normal "next minute" plus clock skew).
-		$delta = $nextRun->timestamp - $now;
+		// And within ~2 minutes of test-now (next-minute boundary plus padding
+		// for clock skew if the test happens to straddle a real-time tick).
+		$delta = $nextRun->timestamp - $now->timestamp;
 		$this->assertGreaterThanOrEqual(0, $delta);
 		$this->assertLessThanOrEqual(120, $delta);
 	}


### PR DESCRIPTION
## Summary

Master CI is failing on the `prefer-lowest` PHP 8.2 matrix:

> `SchedulerRowsTableTest::testChangingWindowFieldsRecomputesNextRun` — Failed asserting that two strings are not identical.

[Failing job](https://github.com/dereuromark/cakephp-queue-scheduler/actions/runs/25702267069/job/75464765294)

## Root cause

`SchedulerRow::calculateNextRun()` calls `CronExpression::getNextRunDate()` with the default `currentTime = 'now'`. The cron-expression library resolves that via `DateTimeImmutable('now')`, which is real wall-clock time — it ignores `Chronos::setTestNow()` that `tests/bootstrap.php` and individual tests rely on.

The CI worker happened to run during a real-time minute (`23:0X`) that sat inside the test's expected `23:00 – 23:30` window. So the original "every minute" result and the post-window-patch result both evaluated to the same wall-clock-relative timestamp, and `assertNotSame()` blew up.

This is a latent bug, not a CI infrastructure issue — any developer running the suite during that wall-clock window would have hit it.

## Fix

Pass the Cake `DateTime` (which honors test-now) into `getNextRunDate()` so the cron library evaluates against the same clock as the surrounding code. Production behavior is unchanged because, with no test-now set, `new DateTime()` returns real now and the cron library still picks the next minute boundary.

`testCalculateNextRunForMinutelyShortcut` previously compared `nextRun->timestamp - time()` with a comment explicitly noting it had to work around the bug. With the bug fixed, it now compares against the test-now clock and the workaround can go.