### PR TITLE
Add DbAdvisoryLock for multi-host scheduler deployments

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -58,6 +58,24 @@ return [
 		// jitter (the heartbeat is written at the *end* of a pass, not the
 		// start). Raise it if you run cron less often than every minute.
 		//'healthyWithinSeconds' => 65,
+
+		// Scheduler dispatch lock. Default omitted = `FileLock` against
+		// `tmp/queue_scheduler.lock`, which only protects against overlap on
+		// the same host. For multi-host setups where cron may fire from any
+		// node, switch to the DbAdvisoryLock (uses `GET_LOCK` on MySQL and
+		// `pg_try_advisory_lock` on Postgres; rejects SQLite). For other
+		// backends pass a Closure returning your own `LockInterface`.
+		//'lock' => [
+		//    'driver' => 'db',
+		//    'connection' => 'default',       // optional, defaults to 'default'
+		//    'name' => 'queue_scheduler:run', // optional, defaults to this string
+		//],
+		// Or, for a custom backend:
+		//'lock' => fn () => new App\Scheduler\RedisLock(...),
+
+		// File-lock path override (only consulted when `lock` is unset or
+		// uses driver=file). Defaults to TMP . 'queue_scheduler.lock'.
+		//'lockPath' => TMP . 'queue_scheduler.lock',
 	],
 	// Icon configuration for the backend UI (optional, but recommended for better UX)
 	// Without this, the UI will use Font Awesome icons from CDN when using the standalone layout.

--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,25 @@ Recommended deployments:
 
 - **Single-host app:** one cron entry on that host. Done.
 - **Multi-host app:** designate one host as the "cron host" and put the cron entry only there. The scheduler dispatches into the queue; the actual jobs are then picked up by `bin/cake queue worker` running on as many hosts as you like. Dispatch is centralized; execution scales out.
-- **Multi-host with no fixed cron host** (e.g. autoscaling fleets where any node may run cron): replace `FileLock` with a cross-host lock — implement `QueueScheduler\Scheduler\Lock\LockInterface` against a DB advisory lock (`GET_LOCK` on MySQL, `pg_try_advisory_lock` on Postgres) or Redis (`SET NX EX`), then inject it via a custom subclass of `RunCommand`. Only with a real cross-host lock is it safe to have more than one cron entry firing at the scheduler.
+- **Multi-host with no fixed cron host** (e.g. autoscaling fleets where any node may run cron): switch the lock from `FileLock` to the bundled `DbAdvisoryLock`, which uses `GET_LOCK` on MySQL/MariaDB and `pg_try_advisory_lock` on PostgreSQL. Both are session-scoped advisory locks on the shared database, so any number of `bin/cake scheduler run` invocations across the fleet coordinate on a single mutex without needing an extra Redis or filesystem dependency. Enable it in your bootstrap:
+
+  ```php
+  use Cake\Core\Configure;
+
+  Configure::write('QueueScheduler.lock', [
+      'driver' => 'db',
+      'connection' => 'default',         // optional, defaults to 'default'
+      'name' => 'queue_scheduler:run',   // optional, defaults to this string
+  ]);
+  ```
+
+  SQLite has no advisory-lock primitive across processes and `DbAdvisoryLock` rejects it at acquire time — keep `FileLock` for SQLite single-host setups. For Redis, Consul, or another custom backend, pass a `Closure` returning your own `LockInterface` implementation:
+
+  ```php
+  Configure::write('QueueScheduler.lock', fn () => new MyRedisLock(/* ... */));
+  ```
+
+  With a real cross-host lock in place it is safe to have more than one cron entry firing at the scheduler.
 
 ### Command flags
 

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -10,7 +10,11 @@ use Cake\Console\CommandInterface;
 use Cake\Console\ConsoleIo;
 use Cake\Console\ConsoleOptionParser;
 use Cake\Core\Configure;
+use Cake\Datasource\ConnectionManager;
 use Cake\Log\LogTrait;
+use Closure;
+use InvalidArgumentException;
+use QueueScheduler\Scheduler\Lock\DbAdvisoryLock;
 use QueueScheduler\Scheduler\Lock\FileLock;
 use QueueScheduler\Scheduler\Lock\LockInterface;
 use QueueScheduler\Scheduler\Scheduler;
@@ -317,13 +321,48 @@ class RunCommand extends Command {
 	/**
 	 * Factory seam for the lock.
 	 *
+	 * Selects the implementation from the `QueueScheduler.lock` Configure
+	 * key. Accepted shapes:
+	 *
+	 *  - missing / null / scalar → legacy `FileLock` path. `QueueScheduler.lockPath`
+	 *    still honored for backwards compatibility.
+	 *  - `['driver' => 'file', 'path' => '/path/to/lockfile']` — explicit
+	 *    file lock; same as the legacy default.
+	 *  - `['driver' => 'db', 'connection' => 'default', 'name' => '…']` —
+	 *    multi-host safe; uses `GET_LOCK` on MySQL and
+	 *    `pg_try_advisory_lock` on Postgres. SQLite is rejected because
+	 *    SQLite has no cross-process advisory primitive.
+	 *  - Closure returning a `LockInterface` — full custom backend (Redis,
+	 *    Consul, etc.).
+	 *
 	 * @return \QueueScheduler\Scheduler\Lock\LockInterface
 	 */
 	protected function createLock(): LockInterface {
-		$path = Configure::read('QueueScheduler.lockPath');
-		if (!is_string($path) || $path === '') {
-			$path = TMP . 'queue_scheduler.lock';
+		$config = Configure::read('QueueScheduler.lock');
+
+		if ($config instanceof Closure) {
+			$lock = $config();
+			if (!$lock instanceof LockInterface) {
+				throw new InvalidArgumentException(
+					'QueueScheduler.lock Closure must return a LockInterface instance.',
+				);
+			}
+
+			return $lock;
 		}
+
+		if (is_array($config) && ($config['driver'] ?? 'file') === 'db') {
+			$connectionName = $config['connection'] ?? 'default';
+			$name = $config['name'] ?? 'queue_scheduler:run';
+			/** @var \Cake\Database\Connection $connection */
+			$connection = ConnectionManager::get($connectionName);
+
+			return new DbAdvisoryLock($connection, (string)$name);
+		}
+
+		$path = is_array($config) && isset($config['path'])
+			? (string)$config['path']
+			: (string)(Configure::read('QueueScheduler.lockPath') ?: TMP . 'queue_scheduler.lock');
 
 		return new FileLock($path);
 	}

--- a/src/Scheduler/Lock/DbAdvisoryLock.php
+++ b/src/Scheduler/Lock/DbAdvisoryLock.php
@@ -1,0 +1,181 @@
+<?php declare(strict_types=1);
+
+namespace QueueScheduler\Scheduler\Lock;
+
+use Cake\Database\Connection;
+use Cake\Database\Driver\Mysql;
+use Cake\Database\Driver\Postgres;
+use RuntimeException;
+
+/**
+ * Cross-host scheduler lock backed by the database's advisory-lock
+ * primitives.
+ *
+ * Multi-host deployments cannot rely on {@see FileLock} because each
+ * host has its own filesystem; this implementation uses session-scoped
+ * advisory locks on the shared database so any number of `bin/cake
+ * scheduler run` invocations across the fleet coordinate on a single
+ * mutex.
+ *
+ * Drivers supported:
+ *
+ * - **MySQL / MariaDB** via `GET_LOCK(name, timeout)` — native blocking
+ *   acquire with a server-side timeout, no client-side polling.
+ * - **PostgreSQL** via `pg_try_advisory_lock(key)` — non-blocking, so
+ *   `acquire()` polls until the deadline. The lock name is hashed to a
+ *   63-bit positive bigint because Postgres advisory locks key on int.
+ *
+ * SQLite is single-process by design (no concurrent writers across
+ * hosts), so a database lock is meaningless there — use {@see FileLock}
+ * instead.
+ *
+ * Both advisory-lock flavors are tied to the connection session. If
+ * the cron process crashes mid-tick the database releases the lock on
+ * connection close, so a stuck lock can never strand the scheduler.
+ *
+ * Wiring (see `config/app.example.php`):
+ *
+ * ```php
+ * Configure::write('QueueScheduler.lock', [
+ *     'driver' => 'db',
+ *     'connection' => 'default', // optional, defaults to 'default'
+ *     'name' => 'queue_scheduler:run', // optional, defaults to this string
+ * ]);
+ * ```
+ */
+class DbAdvisoryLock implements LockInterface {
+
+	/**
+	 * Polling interval used by drivers without a native blocking acquire,
+	 * matching `FileLock` for consistency. Microseconds.
+	 *
+	 * @var int
+	 */
+	protected const POLL_INTERVAL_US = 100_000;
+
+	/**
+	 * MySQL `GET_LOCK` truncates the name at 64 chars (since 5.7). We keep
+	 * the user-visible name shorter than that to leave space for caller-
+	 * supplied prefixes.
+	 *
+	 * @var int
+	 */
+	protected const MYSQL_NAME_MAX_LENGTH = 64;
+
+	protected Connection $connection;
+
+	protected string $name;
+
+	/**
+	 * Tracks whether this instance currently holds the lock. Defensive
+	 * against double-acquire and noop-release.
+	 *
+	 * @var bool
+	 */
+	protected bool $held = false;
+
+	public function __construct(Connection $connection, string $name) {
+		if ($name === '') {
+			throw new RuntimeException('DbAdvisoryLock name must be non-empty.');
+		}
+		if (strlen($name) > static::MYSQL_NAME_MAX_LENGTH) {
+			throw new RuntimeException(sprintf(
+				'DbAdvisoryLock name must be <= %d characters (MySQL GET_LOCK limit); got %d.',
+				static::MYSQL_NAME_MAX_LENGTH,
+				strlen($name),
+			));
+		}
+
+		$this->connection = $connection;
+		$this->name = $name;
+	}
+
+	/**
+	 * @param int $timeout Maximum seconds to wait for the lock.
+	 *
+	 * @return bool
+	 */
+	public function acquire(int $timeout): bool {
+		if ($this->held) {
+			throw new RuntimeException('DbAdvisoryLock already acquired; call release() first');
+		}
+
+		$driver = $this->connection->getDriver();
+
+		if ($driver instanceof Mysql) {
+			$statement = $this->connection->execute(
+				'SELECT GET_LOCK(?, ?)',
+				[$this->name, max(0, $timeout)],
+			);
+			/** @var array<int, mixed>|false $row */
+			$row = $statement->fetch('num');
+			if (is_array($row) && (int)($row[0] ?? 0) === 1) {
+				$this->held = true;
+
+				return true;
+			}
+
+			return false;
+		}
+
+		if ($driver instanceof Postgres) {
+			$key = $this->hashKey();
+			$deadline = microtime(true) + $timeout;
+			do {
+				$statement = $this->connection->execute(
+					'SELECT pg_try_advisory_lock(?)',
+					[$key],
+				);
+				/** @var array<int, mixed>|false $row */
+				$row = $statement->fetch('num');
+				$acquired = is_array($row) && in_array($row[0] ?? false, [true, 't', '1', 1], true);
+				if ($acquired) {
+					$this->held = true;
+
+					return true;
+				}
+				usleep(static::POLL_INTERVAL_US);
+			} while (microtime(true) < $deadline);
+
+			return false;
+		}
+
+		throw new RuntimeException(sprintf(
+			'DbAdvisoryLock supports MySQL and PostgreSQL only; got %s. Use FileLock for SQLite single-host setups.',
+			$driver::class,
+		));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function release(): void {
+		if (!$this->held) {
+			return;
+		}
+
+		$driver = $this->connection->getDriver();
+
+		if ($driver instanceof Mysql) {
+			$this->connection->execute('SELECT RELEASE_LOCK(?)', [$this->name]);
+		} elseif ($driver instanceof Postgres) {
+			$this->connection->execute('SELECT pg_advisory_unlock(?)', [$this->hashKey()]);
+		}
+
+		$this->held = false;
+	}
+
+	/**
+	 * Postgres advisory locks key on bigint. Hash the human-readable lock
+	 * name into a stable positive 63-bit int so the same lock name yields
+	 * the same key across PHP processes.
+	 *
+	 * @return int
+	 */
+	protected function hashKey(): int {
+		$hex = substr(hash('sha256', $this->name), 0, 15);
+
+		return (int)hexdec($hex) & 0x7FFFFFFFFFFFFFFF;
+	}
+
+}

--- a/tests/TestCase/Command/RunCommandTest.php
+++ b/tests/TestCase/Command/RunCommandTest.php
@@ -8,6 +8,9 @@ use Cake\Core\Configure;
 use Cake\I18n\DateTime;
 use Cake\TestSuite\TestCase;
 use QueueScheduler\Command\RunCommand;
+use QueueScheduler\Scheduler\Lock\DbAdvisoryLock;
+use QueueScheduler\Scheduler\Lock\FileLock;
+use QueueScheduler\Scheduler\Lock\LockInterface;
 use ReflectionMethod;
 
 /**
@@ -232,6 +235,55 @@ class RunCommandTest extends TestCase {
 
 		$this->assertExitCode(0);
 		$this->assertNull(Cache::read(RunCommand::HEARTBEAT_KEY, 'default'));
+	}
+
+	/**
+	 * Factory-level coverage of the new `QueueScheduler.lock` shape:
+	 *  - array config with `driver=db` instantiates `DbAdvisoryLock`,
+	 *  - Closure config returning a `LockInterface` is honored verbatim,
+	 *  - missing / scalar config keeps the legacy `FileLock` default
+	 *    (already exercised by every other test in this file).
+	 *
+	 * @return void
+	 */
+	public function testCreateLockHonorsConfigShapes(): void {
+		$command = new RunCommand();
+		$reflection = new ReflectionMethod($command, 'createLock');
+
+		// 1. Driver=db wires DbAdvisoryLock against the configured connection.
+		Configure::write('QueueScheduler.lock', [
+			'driver' => 'db',
+			'connection' => 'test',
+			'name' => 'queue_scheduler:factory_test',
+		]);
+		try {
+			$lock = $reflection->invoke($command);
+			$this->assertInstanceOf(DbAdvisoryLock::class, $lock);
+		} finally {
+			Configure::delete('QueueScheduler.lock');
+		}
+
+		// 2. Closure config — caller-supplied LockInterface is used as-is.
+		$custom = new class implements LockInterface {
+			public function acquire(int $timeout): bool {
+				return true;
+			}
+
+			public function release(): void {
+			}
+		};
+		Configure::write('QueueScheduler.lock', fn () => $custom);
+		try {
+			$this->assertSame($custom, $reflection->invoke($command));
+		} finally {
+			Configure::delete('QueueScheduler.lock');
+		}
+
+		// 3. No config → FileLock default.
+		$this->assertInstanceOf(
+			FileLock::class,
+			$reflection->invoke($command),
+		);
 	}
 
 	public function testLoopExitsCleanlyWhenLockHeld(): void {

--- a/tests/TestCase/Scheduler/Lock/DbAdvisoryLockTest.php
+++ b/tests/TestCase/Scheduler/Lock/DbAdvisoryLockTest.php
@@ -1,0 +1,122 @@
+<?php declare(strict_types=1);
+
+namespace QueueScheduler\Test\TestCase\Scheduler\Lock;
+
+use Cake\Database\Driver\Mysql;
+use Cake\Database\Driver\Postgres;
+use Cake\Database\Driver\Sqlite;
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\TestCase;
+use QueueScheduler\Scheduler\Lock\DbAdvisoryLock;
+use RuntimeException;
+
+class DbAdvisoryLockTest extends TestCase {
+
+	/**
+	 * @return void
+	 */
+	public function testRejectsEmptyName(): void {
+		$connection = ConnectionManager::get('test');
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('non-empty');
+
+		new DbAdvisoryLock($connection, '');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRejectsOverlongName(): void {
+		$connection = ConnectionManager::get('test');
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('64 characters');
+
+		new DbAdvisoryLock($connection, str_repeat('x', 65));
+	}
+
+	/**
+	 * SQLite has no advisory-lock primitive across processes — the impl
+	 * must reject that driver at acquire-time rather than silently
+	 * succeeding (which would imply protection that doesn't exist).
+	 *
+	 * @return void
+	 */
+	public function testRejectsUnsupportedDriver(): void {
+		$connection = ConnectionManager::get('test');
+		if (!$connection->getDriver() instanceof Sqlite) {
+			$this->markTestSkipped('Driver-rejection test only runs on SQLite.');
+		}
+
+		$lock = new DbAdvisoryLock($connection, 'queue_scheduler:test');
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('MySQL and PostgreSQL only');
+
+		$lock->acquire(0);
+	}
+
+	/**
+	 * Acquire + release happy path on a real advisory-lock backend.
+	 * Skipped under SQLite (covered separately) and run for real on
+	 * MySQL / Postgres CI matrices.
+	 *
+	 * @return void
+	 */
+	public function testAcquireAndReleaseOnSupportedDrivers(): void {
+		$connection = ConnectionManager::get('test');
+		$driver = $connection->getDriver();
+		if (!($driver instanceof Mysql || $driver instanceof Postgres)) {
+			$this->markTestSkipped('Advisory-lock acquire/release only runs on MySQL or Postgres.');
+		}
+
+		$lock = new DbAdvisoryLock($connection, 'queue_scheduler:test_happy_path');
+		$this->assertTrue($lock->acquire(1), 'First acquire on an idle name must succeed.');
+
+		$lock->release();
+
+		// After release, the same name can be re-acquired.
+		$this->assertTrue($lock->acquire(1), 'Re-acquire after release on the same instance must succeed.');
+		$lock->release();
+	}
+
+	/**
+	 * Double-acquire from the same instance must throw, mirroring the
+	 * FileLock contract.
+	 *
+	 * @return void
+	 */
+	public function testDoubleAcquireThrows(): void {
+		$connection = ConnectionManager::get('test');
+		$driver = $connection->getDriver();
+		if (!($driver instanceof Mysql || $driver instanceof Postgres)) {
+			$this->markTestSkipped('Advisory-lock acquire only runs on MySQL or Postgres.');
+		}
+
+		$lock = new DbAdvisoryLock($connection, 'queue_scheduler:test_double');
+		$this->assertTrue($lock->acquire(1));
+
+		try {
+			$this->expectException(RuntimeException::class);
+			$this->expectExceptionMessage('already acquired');
+			$lock->acquire(1);
+		} finally {
+			$lock->release();
+		}
+	}
+
+	/**
+	 * release() on a never-acquired (or already-released) instance is a
+	 * no-op, again mirroring FileLock.
+	 *
+	 * @return void
+	 */
+	public function testReleaseWithoutAcquireIsNoop(): void {
+		$connection = ConnectionManager::get('test');
+		$lock = new DbAdvisoryLock($connection, 'queue_scheduler:test_idle');
+		$lock->release();
+		$lock->release();
+		// Reached without exceptions.
+		$this->assertTrue(true);
+	}
+
+}


### PR DESCRIPTION
## Summary

`FileLock` is single-host by design: two app servers running cron each acquire their own local file lock and double-schedule every row. Until now the docs admitted this and pointed users at "implement your own `LockInterface` backend" — fine in theory, but the most common cases (MySQL / Postgres apps) deserved a built-in path.

## What's added

**`DbAdvisoryLock`** — cross-host scheduler lock backed by the shared database's advisory-lock primitives:

| Driver | Primitive | Mode |
|---|---|---|
| MySQL / MariaDB | `GET_LOCK(name, timeout)` / `RELEASE_LOCK(name)` | Native blocking acquire, server-side timeout, no client-side polling |
| PostgreSQL | `pg_try_advisory_lock(key)` / `pg_advisory_unlock(key)` | Non-blocking; `acquire()` polls until the deadline. Lock name hashed to a stable 63-bit positive bigint (substr of sha256) because PG advisory locks key on `int` |
| SQLite | — | Rejected at acquire time; SQLite has no cross-process advisory primitive |

Both flavors are session-scoped: a crashed cron process drops the lock on connection close, so a stuck lock can never strand the scheduler.

## Wiring

New `QueueScheduler.lock` Configure key on `RunCommand::createLock()`. Backwards-compatible — the existing `QueueScheduler.lockPath` is still honored as a `FileLock` fallback. Supported shapes:

| Config | Result |
|---|---|
| *(missing)* / null | Legacy `FileLock` against `lockPath` (or `TMP/queue_scheduler.lock`) |
| `['driver' => 'file', 'path' => '/path']` | Explicit `FileLock` |
| `['driver' => 'db', 'connection' => 'default', 'name' => '...']` | `DbAdvisoryLock` |
| Closure returning `LockInterface` | Custom backend (Redis, Consul, …) |

```php
// config/bootstrap.php
Configure::write('QueueScheduler.lock', [
    'driver' => 'db',
    'connection' => 'default',
    'name' => 'queue_scheduler:run',
]);
```

## Tests

- `DbAdvisoryLockTest` — ctor validation (empty/overlong name), SQLite rejection, acquire/release happy path on MySQL/Postgres (skipped under SQLite — covered on the MySQL/Postgres CI matrices), double-acquire throws, release-without-acquire is a no-op.
- `RunCommandTest::testCreateLockHonorsConfigShapes` — factory wires `DbAdvisoryLock` for `driver=db`, honors a `Closure` returning a `LockInterface`, falls back to `FileLock` when nothing is configured.

143 tests pass (3 skipped — 2 driver-gated lock tests under SQLite + the existing 1); phpcs and phpstan are clean.

## Docs

- `docs/README.md` "Run a single scheduler instance" section rewritten to recommend `DbAdvisoryLock` for multi-host setups, with the exact Configure call.
- `config/app.example.php` documents the new `lock` key with both the array shape and the Closure shape.

## Why this matters

This was the last open top-3 bug for the plugin in the merged review. With it, every multi-host deployment has a first-class, zero-dependency way to ensure exactly one scheduler tick fires at a time without depending on cron-host pinning.
