### PR TITLE
Fix test-now leak that made RowTest fail in CI

### DIFF
--- a/tests/TestCase/Controller/Admin/SchedulerRowsControllerTest.php
+++ b/tests/TestCase/Controller/Admin/SchedulerRowsControllerTest.php
@@ -7,6 +7,7 @@ use Cake\Http\Exception\ForbiddenException;
 use Cake\I18n\DateTime;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
+use QueueScheduler\Test\TestCase\ResetsTestNowTrait;
 
 /**
  * @uses \QueueScheduler\Controller\Admin\SchedulerRowsController
@@ -14,6 +15,7 @@ use Cake\TestSuite\TestCase;
 class SchedulerRowsControllerTest extends TestCase {
 
 	use IntegrationTestTrait;
+	use ResetsTestNowTrait;
 
 	/**
 	 * @var array<string>
@@ -285,7 +287,7 @@ class SchedulerRowsControllerTest extends TestCase {
 			$row = $rowsTable->get($row->id);
 			$this->assertNull($row->get('last_run'));
 		} finally {
-			DateTime::setTestNow(new DateTime());
+			$this->resetTestNow();
 		}
 	}
 
@@ -366,7 +368,7 @@ class SchedulerRowsControllerTest extends TestCase {
 			$payload = is_array($queuedJob->data) ? $queuedJob->data : json_decode((string)$queuedJob->data, true);
 			$this->assertSame(['tenant_id' => 123], $payload);
 		} finally {
-			DateTime::setTestNow(new DateTime());
+			$this->resetTestNow();
 		}
 	}
 

--- a/tests/TestCase/Model/Entity/SchedulerRowTest.php
+++ b/tests/TestCase/Model/Entity/SchedulerRowTest.php
@@ -6,6 +6,7 @@ use Cake\I18n\DateTime;
 use Cake\TestSuite\TestCase;
 use DateInterval;
 use QueueScheduler\Model\Entity\SchedulerRow;
+use QueueScheduler\Test\TestCase\ResetsTestNowTrait;
 
 /**
  * Unit tests for SchedulerRow's frequency / due-time calculations.
@@ -19,15 +20,13 @@ use QueueScheduler\Model\Entity\SchedulerRow;
  */
 class SchedulerRowTest extends TestCase {
 
+	use ResetsTestNowTrait;
+
 	/**
-	 * Reset the frozen test-now to a fresh instance so other test classes that
-	 * rely on a non-null `getTestNow()` (e.g. SchedulerRowsTableTest::testInsert)
-	 * continue to find one. Clearing it to null instead would leak across files.
-	 *
 	 * @return void
 	 */
 	protected function tearDown(): void {
-		DateTime::setTestNow(new DateTime());
+		$this->resetTestNow();
 		parent::tearDown();
 	}
 

--- a/tests/TestCase/Model/Table/SchedulerRowsTableTest.php
+++ b/tests/TestCase/Model/Table/SchedulerRowsTableTest.php
@@ -9,12 +9,15 @@ use Cake\TestSuite\TestCase;
 use Queue\Queue\Task\ExampleTask;
 use QueueScheduler\Model\Entity\SchedulerRow;
 use QueueScheduler\Model\Table\SchedulerRowsTable;
+use QueueScheduler\Test\TestCase\ResetsTestNowTrait;
 use stdClass;
 
 /**
  * QueueScheduler\Model\Table\RowsTable Test Case
  */
 class SchedulerRowsTableTest extends TestCase {
+
+	use ResetsTestNowTrait;
 
 	/**
 	 * Test subject
@@ -371,7 +374,7 @@ class SchedulerRowsTableTest extends TestCase {
 			$this->assertSame('23:00:00', $row->next_run->format('H:i:s'));
 			$this->assertTrue($row->isWithinWindow($row->next_run));
 		} finally {
-			DateTime::setTestNow(new DateTime());
+			$this->resetTestNow();
 		}
 	}
 
@@ -396,7 +399,7 @@ class SchedulerRowsTableTest extends TestCase {
 
 			$this->assertSame('2026-05-13 23:00:00', $row->next_run?->format('Y-m-d H:i:s'));
 		} finally {
-			DateTime::setTestNow(new DateTime());
+			$this->resetTestNow();
 		}
 	}
 
@@ -430,7 +433,7 @@ class SchedulerRowsTableTest extends TestCase {
 			$this->assertSame('23:00:00', $row->next_run->format('H:i:s'));
 			$this->assertTrue($row->isWithinWindow($row->next_run));
 		} finally {
-			DateTime::setTestNow(new DateTime());
+			$this->resetTestNow();
 		}
 	}
 

--- a/tests/TestCase/ResetsTestNowTrait.php
+++ b/tests/TestCase/ResetsTestNowTrait.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace QueueScheduler\Test\TestCase;
+
+use Cake\I18n\DateTime;
+
+/**
+ * Restores the frozen test-now after a test has temporarily overridden it.
+ */
+trait ResetsTestNowTrait {
+
+	/**
+	 * Restore the global test-now to the real wall clock as a frozen, non-null value.
+	 *
+	 * `DateTime::setTestNow(new DateTime())` on its own is not enough: while an
+	 * override is active, `new DateTime()` resolves to the frozen value, so a test
+	 * that pinned a past date would re-freeze that past date and leak it into later
+	 * tests (RowTest::testCalculateNextRunForCronWithoutLastRun then computes a
+	 * "next run" in the past and fails). Clearing the override first lets
+	 * `new DateTime()` read the wall clock again; re-freezing keeps it non-null for
+	 * tests that depend on getTestNow() (SchedulerRowsTableTest::testInsert).
+	 *
+	 * @return void
+	 */
+	protected function resetTestNow(): void {
+		DateTime::setTestNow(null);
+		DateTime::setTestNow(new DateTime());
+	}
+
+}


### PR DESCRIPTION
## Problem

CI on `master` fails on every matrix leg with:

```
QueueScheduler\Test\TestCase\Model\Entity\RowTest::testCalculateNextRunForCronWithoutLastRun
Failed asserting that 1778756400 is greater than 1779365220.
```

`1778756400` is **2026-05-14 11:00:00 UTC** — a date in the past relative to the run. `calculateNextRun()` resolves "now" through Cake's test-aware `DateTime`, and something had frozen that clock to **2026-05-13 12:00:00** (the next `0 11 * * *` slot after that is exactly 2026-05-14 11:00). The assertion compares against the real `time()`, so it fails.

## Root cause

Several tests temporarily freeze the clock and then "reset" it like this:

```php
DateTime::setTestNow(new DateTime('2026-05-13 12:00:00'));
try { /* ... */ }
finally {
    DateTime::setTestNow(new DateTime()); // bug
}
```

While an override is active, `new DateTime()` resolves to the **frozen** value, so the "reset" just re-freezes 2026-05-13 instead of returning to the wall clock. That stale value then leaks into later tests (the controller test has no tearDown, so it bleeds straight into `RowTest`).

Resetting to `null` is not an option either: `SchedulerRowsTableTest::testInsert` reads `getTestNow()` to build its own expectation and relies on the bootstrap freeze being non-null.

## Fix

Add `ResetsTestNowTrait::resetTestNow()`, which clears the override **before** re-freezing at the real wall clock:

```php
DateTime::setTestNow(null);
DateTime::setTestNow(new DateTime());
```

This restores a real, non-null "now" without leaking a stale value, and replaces all the broken reset call sites in the three affected test classes.

## Note

In random execution order the suite also surfaces an **unrelated, pre-existing** order-dependency in `CommandFinderTest::testAll` (reproduces identically on `master` without this change). CI uses the default order and is unaffected; left out of scope here.
