### PR TITLE
Add QueueScheduler import/export workflow

### DIFF
--- a/src/Controller/Admin/QueueSchedulerController.php
+++ b/src/Controller/Admin/QueueSchedulerController.php
@@ -24,6 +24,7 @@ class QueueSchedulerController extends QueueSchedulerAppController {
 		$schedulerRows = $this->fetchTable('QueueScheduler.SchedulerRows')
 			->find('active')
 			->contain(['LastQueuedJob' => ['fields' => ['id', 'fetched', 'completed']]])
+			->orderBy(['SchedulerRows.name' => 'ASC'])
 			->all()
 			->toArray();
 

--- a/src/Controller/Admin/SchedulerRowsController.php
+++ b/src/Controller/Admin/SchedulerRowsController.php
@@ -4,6 +4,7 @@ namespace QueueScheduler\Controller\Admin;
 
 use Cake\Http\Response;
 use Cake\I18n\DateTime;
+use Psr\Http\Message\UploadedFileInterface;
 
 /**
  * Rows Controller
@@ -19,7 +20,9 @@ class SchedulerRowsController extends QueueSchedulerAppController {
 	 * @return void Renders view
 	 */
 	public function index(): void {
-		$rows = $this->paginate($this->SchedulerRows);
+		$rows = $this->paginate($this->SchedulerRows, [
+			'order' => ['SchedulerRows.name' => 'ASC'],
+		]);
 
 		$this->set(compact('rows'));
 	}
@@ -68,6 +71,26 @@ class SchedulerRowsController extends QueueSchedulerAppController {
 			->toArray();
 
 		$this->set(compact('row', 'jobStats', 'recentJobs'));
+	}
+
+	/**
+	 * @param string|null $id Row id.
+	 *
+	 * @return \Cake\Http\Response
+	 */
+	public function export(?string $id = null): Response {
+		$row = $this->SchedulerRows->get($id);
+		$payload = [
+			'queue_scheduler_export' => 1,
+			'exported_at' => DateTime::now()->toIso8601String(),
+			'row' => $this->buildExportPayload($row),
+		];
+		$filename = 'queue-scheduler-' . preg_replace('/[^a-z0-9]+/i', '-', strtolower($row->name)) . '.json';
+
+		return $this->response
+			->withType('application/json')
+			->withDownload($filename)
+			->withStringBody((string)json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 	}
 
 	/**
@@ -153,6 +176,43 @@ class SchedulerRowsController extends QueueSchedulerAppController {
 		$this->set(compact('row'));
 
 		return null;
+	}
+
+	/**
+	 * @return \Cake\Http\Response|null
+	 */
+	public function import(): ?Response {
+		if (!$this->request->is('post')) {
+			return null;
+		}
+
+		$json = $this->readImportJson();
+		if ($json === null) {
+			$this->Flash->error(__d('queue_scheduler', 'Provide a JSON file or paste JSON to import a schedule.'));
+
+			return $this->redirect(['action' => 'import']);
+		}
+
+		$importData = json_decode($json, true);
+		if (!is_array($importData)) {
+			$this->Flash->error(__d('queue_scheduler', 'Invalid import JSON.'));
+
+			return $this->redirect(['action' => 'import']);
+		}
+
+		$rowData = $this->extractImportRowData($importData);
+		if ($rowData === null) {
+			$this->Flash->error(__d('queue_scheduler', 'Import JSON must contain a schedule row payload.'));
+
+			return $this->redirect(['action' => 'import']);
+		}
+
+		$this->Flash->success(__d('queue_scheduler', 'Imported schedule loaded. Review and save the draft.'));
+
+		return $this->redirect([
+			'action' => 'add',
+			'?' => $rowData,
+		]);
 	}
 
 	/**
@@ -263,6 +323,99 @@ class SchedulerRowsController extends QueueSchedulerAppController {
 		}
 
 		return $overrides;
+	}
+
+	/**
+	 * @param \QueueScheduler\Model\Entity\SchedulerRow $row
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected function buildExportPayload(mixed $row): array {
+		$windowStartTime = $row->get('window_start_time');
+		$windowEndTime = $row->get('window_end_time');
+
+		return [
+			'name' => $row->name,
+			'type' => $row->type,
+			'content' => $row->content,
+			'param' => $row->param,
+			'job_config' => $row->job_config ? (string)json_encode($row->job_config, JSON_UNESCAPED_SLASHES) : '',
+			'frequency' => $row->frequency,
+			'allow_concurrent' => $row->allow_concurrent ? 1 : 0,
+			'enabled' => $row->enabled ? 1 : 0,
+			'window_start_time' => is_object($windowStartTime) && method_exists($windowStartTime, 'format') ? $windowStartTime->format('H:i') : $windowStartTime,
+			'window_end_time' => is_object($windowEndTime) && method_exists($windowEndTime, 'format') ? $windowEndTime->format('H:i') : $windowEndTime,
+			'window_days_of_week' => $row->window_days_of_week,
+		];
+	}
+
+	protected function readImportJson(): ?string {
+		$upload = $this->request->getUploadedFile('import_file');
+		if ($upload instanceof UploadedFileInterface && $upload->getError() === UPLOAD_ERR_OK) {
+			$stream = $upload->getStream();
+			$stream->rewind();
+			$content = $stream->getContents();
+
+			return $content !== '' ? $content : null;
+		}
+
+		$json = $this->request->getData('import_json');
+		if (!is_string($json)) {
+			return null;
+		}
+
+		$json = trim($json);
+
+		return $json !== '' ? $json : null;
+	}
+
+	/**
+	 * @param array<string, mixed> $importData
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	protected function extractImportRowData(array $importData): ?array {
+		$rowData = $importData['row'] ?? $importData;
+		if (!is_array($rowData)) {
+			return null;
+		}
+
+		$allowedFields = [
+			'name',
+			'type',
+			'content',
+			'param',
+			'job_config',
+			'frequency',
+			'allow_concurrent',
+			'enabled',
+			'window_start_time',
+			'window_end_time',
+			'window_days_of_week',
+		];
+
+		$result = [];
+		foreach ($allowedFields as $field) {
+			if (!array_key_exists($field, $rowData)) {
+				continue;
+			}
+			$value = $rowData[$field];
+			if (is_array($value) && $field === 'job_config') {
+				$value = (string)json_encode($value, JSON_UNESCAPED_SLASHES);
+			}
+			if (($field === 'allow_concurrent' || $field === 'enabled') && $value !== null) {
+				$value = $value ? 1 : 0;
+			}
+			if ($field === 'param' && is_array($value)) {
+				$value = (string)json_encode($value, JSON_UNESCAPED_SLASHES);
+			}
+			if ($field === 'window_days_of_week' && is_array($value)) {
+				$value = implode(',', $value);
+			}
+			$result[$field] = $value;
+		}
+
+		return $result ?: null;
 	}
 
 	/**

--- a/templates/Admin/QueueScheduler/index.php
+++ b/templates/Admin/QueueScheduler/index.php
@@ -23,6 +23,11 @@ if ($schedulerStatus['lastTick'] !== null) {
 		</h2>
 		<div>
 			<?= $this->Html->link(
+				'<i class="fas fa-file-import me-1"></i>' . __d('queue_scheduler', 'Import Schedule'),
+				['controller' => 'SchedulerRows', 'action' => 'import'],
+				['class' => 'btn btn-outline-secondary me-2', 'escapeTitle' => false],
+			) ?>
+			<?= $this->Html->link(
 				'<i class="fas fa-plus me-1"></i>' . __d('queue_scheduler', 'New Schedule'),
 				['controller' => 'SchedulerRows', 'action' => 'add'],
 				['class' => 'btn btn-primary', 'escapeTitle' => false],

--- a/templates/Admin/SchedulerRows/add.php
+++ b/templates/Admin/SchedulerRows/add.php
@@ -139,7 +139,6 @@ $windowOpen = $hasWindowValues || $hasWindowErrors;
 									'0' => __d('queue_scheduler', 'Sun'),
 								],
 								'label' => __d('queue_scheduler', 'Allowed Days'),
-								'hiddenField' => false,
 								'value' => $selectedWindowDays,
 								'help' => __d('queue_scheduler', 'Leave all unchecked for every day.'),
 							]) ?>

--- a/templates/Admin/SchedulerRows/add.php
+++ b/templates/Admin/SchedulerRows/add.php
@@ -65,46 +65,46 @@ $windowOpen = $hasWindowValues || $hasWindowErrors;
 			<div class="mb-3">
 				<?= $this->Form->control('param', ['class' => 'form-control']) ?>
 			</div>
-				<div class="mb-3">
-					<?= $this->Form->control('job_config', [
-						'type' => 'textarea',
-						'rows' => 3,
-						'class' => 'form-control',
+			<div class="mb-3">
+				<?= $this->Form->control('job_config', [
+					'type' => 'textarea',
+					'rows' => 3,
+					'class' => 'form-control',
 					'label' => __d('queue_scheduler', 'Job Config (JSON)'),
 					'placeholder' => '{"priority": 5, "group": "batch"}',
-						'help' => __d('queue_scheduler', 'Optional JSON object. Allowed keys: priority (1-10, lower runs sooner; default 5) and group (worker group, matches `cake queue worker --group=...`).'),
-					]) ?>
+					'help' => __d('queue_scheduler', 'Optional JSON object. Allowed keys: priority (1-10, lower runs sooner; default 5) and group (worker group, matches `cake queue worker --group=...`).'),
+				]) ?>
+			</div>
+			<div class="row">
+				<div class="col-md-6 mb-3">
+					<?= $this->Form->control('frequency', ['list' => 'frequency-suggestions', 'class' => 'form-control']) ?>
 				</div>
-				<div class="row">
-					<div class="col-md-6 mb-3">
-						<?= $this->Form->control('frequency', ['list' => 'frequency-suggestions', 'class' => 'form-control']) ?>
-					</div>
-					<div class="col-md-3 mb-3">
-						<?= $this->Form->control('allow_concurrent', ['class' => 'form-check-input']) ?>
-					</div>
-					<div class="col-md-3 mb-3">
-						<?= $this->Form->control('enabled', ['class' => 'form-check-input']) ?>
-					</div>
+				<div class="col-md-3 mb-3">
+					<?= $this->Form->control('allow_concurrent', ['class' => 'form-check-input']) ?>
 				</div>
-				<div class="card bg-light-subtle border-0 mb-3">
-					<div class="card-body">
-						<div class="d-flex justify-content-between align-items-center mb-2">
-							<div>
-								<h5 class="mb-1"><?= __d('queue_scheduler', 'Dispatch Window (optional)') ?></h5>
-								<div class="small text-muted">
-									<?= $hasWindowValues ? __d('queue_scheduler', 'Restrictions configured') : __d('queue_scheduler', 'No restrictions') ?>
-								</div>
+				<div class="col-md-3 mb-3">
+					<?= $this->Form->control('enabled', ['class' => 'form-check-input']) ?>
+				</div>
+			</div>
+			<div class="card bg-light-subtle border-0 mb-3">
+				<div class="card-body">
+					<div class="d-flex justify-content-between align-items-center mb-2">
+						<div>
+							<h5 class="mb-1"><?= __d('queue_scheduler', 'Dispatch Window (optional)') ?></h5>
+							<div class="small text-muted">
+								<?= $hasWindowValues ? __d('queue_scheduler', 'Restrictions configured') : __d('queue_scheduler', 'No restrictions') ?>
 							</div>
-							<button
-								type="button"
-								class="btn btn-sm btn-outline-secondary"
-								data-bs-toggle="collapse"
-								data-bs-target="#scheduler-window-fields"
-								aria-expanded="<?= $windowOpen ? 'true' : 'false' ?>"
-								aria-controls="scheduler-window-fields"
-							><?= $windowOpen ? __d('queue_scheduler', 'Hide') : __d('queue_scheduler', 'Configure') ?></button>
 						</div>
-						<div id="scheduler-window-fields" class="collapse<?= $windowOpen ? ' show' : '' ?>">
+						<button
+							type="button"
+							class="btn btn-sm btn-outline-secondary"
+							data-bs-toggle="collapse"
+							data-bs-target="#scheduler-window-fields"
+							aria-expanded="<?= $windowOpen ? 'true' : 'false' ?>"
+							aria-controls="scheduler-window-fields"
+						><?= $windowOpen ? __d('queue_scheduler', 'Hide') : __d('queue_scheduler', 'Configure') ?></button>
+					</div>
+					<div id="scheduler-window-fields" class="collapse<?= $windowOpen ? ' show' : '' ?>">
 						<div class="row">
 							<div class="col-md-6 mb-3">
 								<?= $this->Form->control('window_start_time', [
@@ -147,14 +147,13 @@ $windowOpen = $hasWindowValues || $hasWindowErrors;
 							<?php } ?>
 							<div class="form-text"><?= __d('queue_scheduler', 'Weekday-only example: Mon-Fri.') ?></div>
 						</div>
-						</div>
 					</div>
 				</div>
-				</div>
-				<div class="mt-3">
-					<?= $this->Form->button('<i class="fas fa-save me-1"></i>' . __d('queue_scheduler', 'Save'), ['class' => 'btn btn-primary', 'escapeTitle' => false]) ?>
-				</div>
-				<?= $this->Form->end() ?>
+			</div>
+			<div class="mt-3">
+				<?= $this->Form->button('<i class="fas fa-save me-1"></i>' . __d('queue_scheduler', 'Save'), ['class' => 'btn btn-primary', 'escapeTitle' => false]) ?>
+			</div>
+			<?= $this->Form->end() ?>
 		</div>
 	</div>
 

--- a/templates/Admin/SchedulerRows/add.php
+++ b/templates/Admin/SchedulerRows/add.php
@@ -30,7 +30,7 @@ $windowOpen = $hasWindowValues || $hasWindowErrors;
 			<?= $this->Html->link(
 				'<i class="fas fa-clock me-1"></i>' . __d('queue_scheduler', 'Intervals Help'),
 				['controller' => 'QueueScheduler', 'action' => 'intervals'],
-				['class' => 'btn btn-outline-secondary', 'escapeTitle' => false],
+				['class' => 'btn btn-outline-secondary', 'escapeTitle' => false, 'target' => '_blank', 'rel' => 'noopener'],
 			) ?>
 		</div>
 	</div>

--- a/templates/Admin/SchedulerRows/edit.php
+++ b/templates/Admin/SchedulerRows/edit.php
@@ -159,7 +159,6 @@ $windowOpen = $hasWindowValues || $hasWindowErrors;
 									'0' => __d('queue_scheduler', 'Sun'),
 								],
 									'label' => __d('queue_scheduler', 'Allowed Days'),
-									'hiddenField' => false,
 									'value' => $selectedWindowDays,
 									'help' => __d('queue_scheduler', 'Leave all unchecked for every day.'),
 								]) ?>

--- a/templates/Admin/SchedulerRows/edit.php
+++ b/templates/Admin/SchedulerRows/edit.php
@@ -83,49 +83,49 @@ $windowOpen = $hasWindowValues || $hasWindowErrors;
 			<div class="mb-3">
 				<?= $this->Form->control('param', ['class' => 'form-control']) ?>
 			</div>
-				<div class="mb-3">
-					<?= $this->Form->control('job_config', [
-						'type' => 'textarea',
-						'rows' => 3,
-						'class' => 'form-control',
+			<div class="mb-3">
+				<?= $this->Form->control('job_config', [
+					'type' => 'textarea',
+					'rows' => 3,
+					'class' => 'form-control',
 					'label' => __d('queue_scheduler', 'Job Config (JSON)'),
 					'placeholder' => '{"priority": 5, "group": "batch"}',
-						'help' => __d('queue_scheduler', 'Optional JSON object. Allowed keys: priority (1-10, lower runs sooner; default 5) and group (worker group, matches `cake queue worker --group=...`).'),
-					]) ?>
+					'help' => __d('queue_scheduler', 'Optional JSON object. Allowed keys: priority (1-10, lower runs sooner; default 5) and group (worker group, matches `cake queue worker --group=...`).'),
+				]) ?>
+			</div>
+			<div class="row">
+				<div class="col-md-6 mb-3">
+					<?= $this->Form->control('frequency', ['list' => 'frequency-suggestions', 'class' => 'form-control']) ?>
 				</div>
-				<div class="row">
-					<div class="col-md-6 mb-3">
-						<?= $this->Form->control('frequency', ['list' => 'frequency-suggestions', 'class' => 'form-control']) ?>
-					</div>
-					<div class="col-md-3 mb-3">
-						<?= $this->Form->control('allow_concurrent', ['class' => 'form-check-input']) ?>
-					</div>
-					<div class="col-md-3 mb-3">
-						<?= $this->Form->control('enabled', ['class' => 'form-check-input']) ?>
-					</div>
+				<div class="col-md-3 mb-3">
+					<?= $this->Form->control('allow_concurrent', ['class' => 'form-check-input']) ?>
 				</div>
-					<div class="card bg-light-subtle border-0 mb-3">
-						<div class="card-body">
-							<div class="d-flex justify-content-between align-items-center mb-2">
-								<div>
-									<h5 class="mb-1"><?= __d('queue_scheduler', 'Dispatch Window (optional)') ?></h5>
-									<div class="small text-muted">
-										<?= $hasWindowValues ? __d('queue_scheduler', 'Restrictions configured') : __d('queue_scheduler', 'No restrictions') ?>
-									</div>
-								</div>
-								<button
-									type="button"
-									class="btn btn-sm btn-outline-secondary"
-									data-bs-toggle="collapse"
-									data-bs-target="#scheduler-window-fields"
-									aria-expanded="<?= $windowOpen ? 'true' : 'false' ?>"
-									aria-controls="scheduler-window-fields"
-								><?= $windowOpen ? __d('queue_scheduler', 'Hide') : __d('queue_scheduler', 'Configure') ?></button>
+				<div class="col-md-3 mb-3">
+					<?= $this->Form->control('enabled', ['class' => 'form-check-input']) ?>
+				</div>
+			</div>
+			<div class="card bg-light-subtle border-0 mb-3">
+				<div class="card-body">
+					<div class="d-flex justify-content-between align-items-center mb-2">
+						<div>
+							<h5 class="mb-1"><?= __d('queue_scheduler', 'Dispatch Window (optional)') ?></h5>
+							<div class="small text-muted">
+								<?= $hasWindowValues ? __d('queue_scheduler', 'Restrictions configured') : __d('queue_scheduler', 'No restrictions') ?>
 							</div>
-							<div id="scheduler-window-fields" class="collapse<?= $windowOpen ? ' show' : '' ?>">
-							<div class="row">
-								<div class="col-md-6 mb-3">
-									<?= $this->Form->control('window_start_time', [
+						</div>
+						<button
+							type="button"
+							class="btn btn-sm btn-outline-secondary"
+							data-bs-toggle="collapse"
+							data-bs-target="#scheduler-window-fields"
+							aria-expanded="<?= $windowOpen ? 'true' : 'false' ?>"
+							aria-controls="scheduler-window-fields"
+						><?= $windowOpen ? __d('queue_scheduler', 'Hide') : __d('queue_scheduler', 'Configure') ?></button>
+					</div>
+					<div id="scheduler-window-fields" class="collapse<?= $windowOpen ? ' show' : '' ?>">
+						<div class="row">
+							<div class="col-md-6 mb-3">
+								<?= $this->Form->control('window_start_time', [
 									'type' => 'text',
 									'class' => 'form-control',
 									'label' => __d('queue_scheduler', 'Start'),
@@ -158,23 +158,22 @@ $windowOpen = $hasWindowValues || $hasWindowErrors;
 									'6' => __d('queue_scheduler', 'Sat'),
 									'0' => __d('queue_scheduler', 'Sun'),
 								],
-									'label' => __d('queue_scheduler', 'Allowed Days'),
-									'value' => $selectedWindowDays,
-									'help' => __d('queue_scheduler', 'Leave all unchecked for every day.'),
-								]) ?>
+								'label' => __d('queue_scheduler', 'Allowed Days'),
+								'value' => $selectedWindowDays,
+								'help' => __d('queue_scheduler', 'Leave all unchecked for every day.'),
+							]) ?>
 							<?php if ($row->getError('window_days_of_week')) { ?>
 								<div class="invalid-feedback d-block"><?= h(implode(', ', $row->getError('window_days_of_week'))) ?></div>
-								<?php } ?>
-								<div class="form-text"><?= __d('queue_scheduler', 'Weekday-only example: Mon-Fri.') ?></div>
-							</div>
-							</div>
-							</div>
+							<?php } ?>
+							<div class="form-text"><?= __d('queue_scheduler', 'Weekday-only example: Mon-Fri.') ?></div>
 						</div>
 					</div>
-				<div class="mt-3">
-					<?= $this->Form->button('<i class="fas fa-save me-1"></i>' . __d('queue_scheduler', 'Save'), ['class' => 'btn btn-primary', 'escapeTitle' => false]) ?>
 				</div>
-				<?= $this->Form->end() ?>
+			</div>
+			<div class="mt-3">
+				<?= $this->Form->button('<i class="fas fa-save me-1"></i>' . __d('queue_scheduler', 'Save'), ['class' => 'btn btn-primary', 'escapeTitle' => false]) ?>
+			</div>
+			<?= $this->Form->end() ?>
 		</div>
 	</div>
 

--- a/templates/Admin/SchedulerRows/edit.php
+++ b/templates/Admin/SchedulerRows/edit.php
@@ -52,7 +52,7 @@ $windowOpen = $hasWindowValues || $hasWindowErrors;
 			<?= $this->Html->link(
 				'<i class="fas fa-clock me-1"></i>' . __d('queue_scheduler', 'Intervals Help'),
 				['controller' => 'QueueScheduler', 'action' => 'intervals'],
-				['class' => 'btn btn-outline-secondary', 'escapeTitle' => false],
+				['class' => 'btn btn-outline-secondary', 'escapeTitle' => false, 'target' => '_blank', 'rel' => 'noopener'],
 			) ?>
 		</div>
 	</div>

--- a/templates/Admin/SchedulerRows/import.php
+++ b/templates/Admin/SchedulerRows/import.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @var \App\View\AppView $this
+ */
+?>
+<div class="scheduler-rows-import">
+	<div class="d-flex justify-content-between align-items-center mb-4">
+		<h2 class="mb-0">
+			<i class="fas fa-file-import me-2"></i><?= __d('queue_scheduler', 'Import Schedule') ?>
+		</h2>
+		<div>
+			<?= $this->Html->link(
+				'<i class="fas fa-arrow-left me-1"></i>' . __d('queue_scheduler', 'Back'),
+				['action' => 'index'],
+				['class' => 'btn btn-secondary', 'escapeTitle' => false],
+			) ?>
+		</div>
+	</div>
+
+	<div class="card border-secondary">
+		<div class="card-header bg-light">
+			<i class="fas fa-file-import me-2"></i><?= __d('queue_scheduler', 'Import Schedule Draft') ?>
+		</div>
+		<div class="card-body">
+			<p class="text-muted small mb-3">
+				<?= __d('queue_scheduler', 'Import a previously exported schedule JSON. The scheduler will redirect to the add form with the fields pre-filled so you can review or customize before saving.') ?>
+			</p>
+			<?= $this->Form->create(null, [
+				'url' => ['action' => 'import'],
+				'type' => 'file',
+			]) ?>
+			<div class="row">
+				<div class="col-md-6 mb-3">
+					<?= $this->Form->control('import_file', [
+						'type' => 'file',
+						'label' => __d('queue_scheduler', 'JSON File'),
+						'accept' => '.json,application/json',
+						'class' => 'form-control',
+					]) ?>
+				</div>
+				<div class="col-md-6 mb-3">
+					<?= $this->Form->control('import_json', [
+						'type' => 'textarea',
+						'label' => __d('queue_scheduler', 'Or Paste JSON'),
+						'rows' => 8,
+						'class' => 'form-control font-monospace',
+						'placeholder' => '{"row":{"name":"Nightly job"}}',
+					]) ?>
+				</div>
+			</div>
+			<?= $this->Form->button(
+				'<i class="fas fa-upload me-1"></i>' . __d('queue_scheduler', 'Load Into Add Form'),
+				['class' => 'btn btn-secondary', 'escapeTitle' => false],
+			) ?>
+			<?= $this->Form->end() ?>
+		</div>
+	</div>
+</div>

--- a/templates/Admin/SchedulerRows/index.php
+++ b/templates/Admin/SchedulerRows/index.php
@@ -11,6 +11,11 @@
 		</h2>
 		<div>
 			<?= $this->Html->link(
+				'<i class="fas fa-file-import me-1"></i>' . __d('queue_scheduler', 'Import Schedule'),
+				['action' => 'import'],
+				['class' => 'btn btn-outline-secondary me-2', 'escapeTitle' => false],
+			) ?>
+			<?= $this->Html->link(
 				'<i class="fas fa-plus me-1"></i>' . __d('queue_scheduler', 'New Schedule'),
 				['action' => 'add'],
 				['class' => 'btn btn-primary', 'escapeTitle' => false],

--- a/templates/Admin/SchedulerRows/view.php
+++ b/templates/Admin/SchedulerRows/view.php
@@ -203,9 +203,10 @@ $windowDays = $row->get('window_days_of_week');
 									<?php } ?>
 								</td>
 							</tr>
-						</table>
-					</div>
+					</table>
 				</div>
+			</div>
+			</div>
 		</div>
 
 		<div class="col-lg-6 mb-4">

--- a/templates/Admin/SchedulerRows/view.php
+++ b/templates/Admin/SchedulerRows/view.php
@@ -38,6 +38,11 @@ $windowDays = $row->get('window_days_of_week');
 				['action' => 'edit', $row->id],
 				['class' => 'btn btn-primary me-2', 'escapeTitle' => false],
 			) ?>
+			<?= $this->Html->link(
+				'<i class="fas fa-file-export me-1"></i>' . __d('queue_scheduler', 'Export JSON'),
+				['action' => 'export', $row->id],
+				['class' => 'btn btn-outline-primary me-2', 'escapeTitle' => false],
+			) ?>
 			<?= $this->Form->postButton(
 				'<i class="fas fa-play-circle me-1"></i>' . __d('queue_scheduler', 'Run Now'),
 				['action' => 'run', $row->id],


### PR DESCRIPTION
## Summary
- add schedule export as JSON from the scheduler row view
- add a dedicated import page that preloads the add form for review before saving
- open interval help in a new tab and make scheduler list ordering deterministic by name

## Notes
- scheduler rows index default order: name ASC
- scheduler dashboard default order: name ASC