### PR TITLE
Don't wedge a non-concurrent schedule behind a dead job

### DIFF
--- a/src/Model/Entity/SchedulerRow.php
+++ b/src/Model/Entity/SchedulerRow.php
@@ -557,7 +557,7 @@ class SchedulerRow extends Entity {
 	protected function _getJobData(): array {
 		$param = [];
 		if ($this->param) {
-			$decoded = json_decode($this->param, true, JSON_THROW_ON_ERROR);
+			$decoded = json_decode($this->param, true, 512, JSON_THROW_ON_ERROR);
 			// Validation rejects scalar/null payloads at save time, but a row
 			// inserted directly via SQL or through a marshalling path that
 			// bypasses validation could still reach this method. Falling

--- a/src/Model/Table/SchedulerRowsTable.php
+++ b/src/Model/Table/SchedulerRowsTable.php
@@ -505,7 +505,7 @@ class SchedulerRowsTable extends Table {
 		return $this->getConnection()->transactional(function () use ($row, $config, $oldLastRun): bool {
 			/** @var \Queue\Model\Table\QueuedJobsTable $queuedJobsTable */
 			$queuedJobsTable = TableRegistry::getTableLocator()->get('Queue.QueuedJobs');
-			if (!$row->allow_concurrent && $queuedJobsTable->isQueued($row->job_reference, $row->job_task)) {
+			if (!$row->allow_concurrent && $this->isBlockedByActiveJob($queuedJobsTable, $row)) {
 				return false;
 			}
 
@@ -600,7 +600,7 @@ class SchedulerRowsTable extends Table {
 		return $this->getConnection()->transactional(function () use ($row, $jobData, $config, $overrides): bool {
 			/** @var \Queue\Model\Table\QueuedJobsTable $queuedJobsTable */
 			$queuedJobsTable = TableRegistry::getTableLocator()->get('Queue.QueuedJobs');
-			if (!$row->allow_concurrent && $queuedJobsTable->isQueued($row->job_reference, $row->job_task)) {
+			if (!$row->allow_concurrent && $this->isBlockedByActiveJob($queuedJobsTable, $row)) {
 				return false;
 			}
 
@@ -630,6 +630,53 @@ class SchedulerRowsTable extends Table {
 			// cron-fired rail continues to tick at its normal time.
 			return true;
 		});
+	}
+
+	/**
+	 * Whether a non-concurrent row is blocked by a genuinely in-flight job.
+	 *
+	 * Plain `QueuedJobsTable::isQueued()` treats every `completed IS NULL`
+	 * row as blocking — including a job a worker fetched and then died on
+	 * (OOM, timeout, kill) without ever completing or failing it. Such a row
+	 * stays `completed IS NULL` forever, so a non-concurrent schedule would
+	 * wedge permanently behind it: both the cron tick and the admin "Run"
+	 * action keep returning false ("could not be added to the queue").
+	 *
+	 * A job fetched longer ago than the queue's own requeue timeout is one
+	 * the queue itself would re-offer to a worker, so it is presumed dead and
+	 * no longer counts as blocking here. When `Queue.defaultRequeueTimeout`
+	 * is not configured we fall back to the original strict semantics so
+	 * behaviour is unchanged for installs that have not opted into a timeout.
+	 *
+	 * (Mirrors the `$staleTimeout` parameter added to
+	 * `QueuedJobsTable::isQueued()` in dereuromark/cakephp-queue#503; once a
+	 * release carrying that parameter is required, this can collapse to a
+	 * single `isQueued($ref, $task, $staleTimeout)` call.)
+	 *
+	 * @param \Queue\Model\Table\QueuedJobsTable $queuedJobsTable
+	 * @param \QueueScheduler\Model\Entity\SchedulerRow $row
+	 *
+	 * @return bool
+	 */
+	protected function isBlockedByActiveJob(object $queuedJobsTable, SchedulerRow $row): bool {
+		$staleTimeout = Configure::read('Queue.defaultRequeueTimeout');
+		if (!is_numeric($staleTimeout) || (int)$staleTimeout <= 0) {
+			return $queuedJobsTable->isQueued($row->job_reference, $row->job_task);
+		}
+
+		$conditions = [
+			'reference' => $row->job_reference,
+			'completed IS' => null,
+			'OR' => [
+				'fetched IS' => null,
+				'fetched >=' => (new DateTime())->subSeconds((int)$staleTimeout),
+			],
+		];
+		if ($row->job_task !== null) {
+			$conditions['job_task'] = $row->job_task;
+		}
+
+		return (bool)$queuedJobsTable->find()->where($conditions)->select(['id'])->first();
 	}
 
 	/**

--- a/tests/TestCase/Model/Table/SchedulerRowsTableTest.php
+++ b/tests/TestCase/Model/Table/SchedulerRowsTableTest.php
@@ -625,6 +625,88 @@ class SchedulerRowsTableTest extends TestCase {
 	 *
 	 * @return void
 	 */
+	/**
+	 * A non-concurrent row must NOT stay wedged behind a job that a worker
+	 * fetched and then died on. Once that fetch is older than the queue's
+	 * requeue timeout the job is presumed dead, so the next tick dispatches
+	 * again instead of holding back forever.
+	 *
+	 * @return void
+	 */
+	public function testRunIgnoresStaleQueuedJob(): void {
+		$this->loadPlugins(['Tools', 'Queue', 'QueueScheduler']);
+		Configure::write('Queue.defaultRequeueTimeout', 60);
+
+		$row = $this->SchedulerRows->newEntity([
+			'name' => 'stale-target',
+			'type' => SchedulerRow::TYPE_QUEUE_TASK,
+			'content' => ExampleTask::class,
+			'job_config' => null,
+			'job_data' => '',
+			'frequency' => '+1 hour',
+			'allow_concurrent' => false,
+		]);
+		$this->SchedulerRows->saveOrFail($row);
+		$row = $this->SchedulerRows->get($row->id);
+
+		$this->assertTrue($this->SchedulerRows->run($row));
+		$row = $this->SchedulerRows->get($row->id);
+
+		$queuedJobsTable = $this->getTableLocator()->get('Queue.QueuedJobs');
+		$this->assertSame(1, $queuedJobsTable->find()->count());
+
+		// Mark the existing job as fetched 5 minutes ago and never completed:
+		// a worker grabbed it and vanished.
+		$queuedJob = $queuedJobsTable->get($row->last_queued_job_id);
+		$queuedJob->fetched = (new DateTime())->subSeconds(300);
+		$queuedJob->completed = null;
+		$queuedJobsTable->saveOrFail($queuedJob);
+
+		// Next tick must dispatch despite the dead job (300s > 60s timeout).
+		$this->assertTrue($this->SchedulerRows->run($row));
+		$this->assertSame(2, $queuedJobsTable->find()->count());
+
+		Configure::delete('Queue.defaultRequeueTimeout');
+	}
+
+	/**
+	 * A genuinely in-flight job (fetched within the requeue window, or not
+	 * yet fetched at all) must still block a non-concurrent row.
+	 *
+	 * @return void
+	 */
+	public function testRunBlocksOnFreshQueuedJob(): void {
+		$this->loadPlugins(['Tools', 'Queue', 'QueueScheduler']);
+		Configure::write('Queue.defaultRequeueTimeout', 60);
+
+		$row = $this->SchedulerRows->newEntity([
+			'name' => 'fresh-target',
+			'type' => SchedulerRow::TYPE_QUEUE_TASK,
+			'content' => ExampleTask::class,
+			'job_config' => null,
+			'job_data' => '',
+			'frequency' => '+1 hour',
+			'allow_concurrent' => false,
+		]);
+		$this->SchedulerRows->saveOrFail($row);
+		$row = $this->SchedulerRows->get($row->id);
+
+		$this->assertTrue($this->SchedulerRows->run($row));
+		$row = $this->SchedulerRows->get($row->id);
+
+		$queuedJobsTable = $this->getTableLocator()->get('Queue.QueuedJobs');
+		$queuedJob = $queuedJobsTable->get($row->last_queued_job_id);
+		$queuedJob->fetched = (new DateTime())->subSeconds(10);
+		$queuedJob->completed = null;
+		$queuedJobsTable->saveOrFail($queuedJob);
+
+		// Fetched 10s ago, within the 60s window => still in flight => blocked.
+		$this->assertFalse($this->SchedulerRows->run($row));
+		$this->assertSame(1, $queuedJobsTable->find()->count());
+
+		Configure::delete('Queue.defaultRequeueTimeout');
+	}
+
 	public function testRunIsIdempotentAcrossOverlappingTicks(): void {
 		// Load alongside Tools + QueueScheduler so the plugin registry matches
 		// what Application::bootstrap() loads in the test app. Loading only


### PR DESCRIPTION
## Problem

A non-concurrent row (`allow_concurrent = false`) gates its next dispatch on `QueuedJobsTable::isQueued($reference, $task)`, which counts any row with `completed IS NULL`.

If a worker fetches the scheduled job and then dies (OOM, PHP timeout, container kill) without completing or failing it, that row stays `completed IS NULL` forever. From then on:

- every cron tick is held back, and
- the admin "Run" action returns false ("The job could not be added to the queue"),

with no way out short of manually deleting the ghost row. The schedule is permanently wedged behind a job that will never finish — and to an operator it just looks "stuck running".

## Change

`run()` and `runOnce()` now decide hold-back through a new `isBlockedByActiveJob()` helper:

- A job fetched longer ago than the queue's own requeue timeout (`Queue.defaultRequeueTimeout`) is one the queue would already re-offer to a worker, so it is presumed dead and no longer blocks dispatch.
- Jobs not yet fetched, or fetched within the window, still block — genuine concurrency protection is unchanged.
- When `Queue.defaultRequeueTimeout` is not configured, the original strict `isQueued()` semantics are kept, so behaviour is unchanged for installs that have not opted into a timeout.

## Relationship to cakephp-queue#503

This mirrors the optional `$staleTimeout` parameter proposed for `QueuedJobsTable::isQueued()` in dereuromark/cakephp-queue#503. This PR is intentionally self-contained (no version bump, green on the current released queue) by doing the staleness query locally. Once a queue release carrying that parameter is required, `isBlockedByActiveJob()` can collapse to a single `isQueued($ref, $task, $staleTimeout)` call.

## Tests

`testRunIgnoresStaleQueuedJob` (a 5-minutes-ago fetched, never-completed job no longer blocks) and `testRunBlocksOnFreshQueuedJob` (a 10-seconds-ago fetched job still blocks). Full `SchedulerRowsTableTest` green; phpcs and phpstan clean on the changed files.
